### PR TITLE
Docs: update getting started

### DIFF
--- a/documentation/tutorials/getting-started-with-json-api.md
+++ b/documentation/tutorials/getting-started-with-json-api.md
@@ -1,23 +1,66 @@
 # Getting started with JSON:API
 
-The easiest set up involves using Phoenix, but it should be roughly the same to set up an application using only Plug.
+The easiest set up involves using Phoenix, but it should be roughly the same to set up an
+application using only Plug. We are showing examples using Phoenix Routers.
 
-## Configure your resources and API
+The resulting JSON APIs follow the specifications from https://jsonapi.org/.
+## Configure your Resources and API
 
-See the DSL documentation for information on configuring
+Both your Resource and API need to use the extension for the JSON API.
+
+```elixir
+defmodule Helpdesk.Support do
+  use Ash.Api, extensions: [AshJsonApi.Api]
+  ...
+```
+
+Additionally, your Resource requires a type, a base route and a set of allowed HTTP methods
+and what action they will trigger.
+
+```elixir
+defmodule Helpdesk.Support.Ticket do
+  use Ash.Resource, extensions: [AshJsonApi.Resource]
+  # ...
+  json_api do
+    type "ticket"
+
+    routes do
+      base "/tickets"
+
+      get :read
+      index :read
+      post :create
+      # ...
+    end
+  end
+end
+```
+
+Check out the [AshJsonApi.Resource documentation on
+Hex](https://hexdocs.pm/ash_json_api/AshJsonApi.Resource.html) for more information.
+
+Now, with everything in place, we need to make the new routes available in our main Router.
 
 ## Create a router
 
+Create a separate Router Module to work with your Api and Registry. It will generate the routes for
+your Resources and provide the functions you would usually have in a Controller.
+
+We will later forward requests from your Applications primary (Phoenix) Router to you Ash JSON API Router.
+
 ```elixir
-defmodule MyApp.MyApi.Router do
-  # The registry must be explicitly provided here
-  use AshJsonApi.Api.Router, api: Api, registry: Registry 
+defmodule HelpdeskWeb.Support.Router do
+  use AshJsonApi.Api.Router,
+    # Your Ash.Api Module
+    api: Helpdesk.Support,
+    # Your Ash.Registry Module
+    registry: Helpdesk.Support.Registry
 end
 ```
 
 ## Accept json_api content type
 
-Add the following to your `config/config.exs`
+Add the following to your `config/config.exs`.
 
 ```elixir
 # config/config.exs
@@ -28,20 +71,66 @@ config :mime, :types, %{
 
 This configuration is required to support working with the JSON:API custom mime type.
 
+After adding the configuration above, compiling the project might throw an error:
+```
+ERROR! the application :mime has a different value set for key :types during runtime compared to compile time.
+```
+This can happen if `:mime` was already compiled before the configuration was changed and can be
+fixed by running 
+```
+mix deps.compile mime --force
+```
+
 ## Add the routes from your API module(s)
 
-Forward requests to the from your Phoenix router to the router you created for your Api.
+To make your Resources accessible to the outside world, forward requests from your Phoenix router to the router you created for your Api.
 
 For example:
 
 ```elixir
-scope "/json_api" do
+scope "/api/json" do
   pipe_through(:api)
 
-  forward "/helpdesk", MyApp.MyApi.Router
+  forward "/helpdesk", HelpdeskWeb.Support.Router
 end
 ```
 
 ## Run your API
 
-From here on out its the standard phoenix behavior. Start your application with `mix phx.server` and your API should be ready to try out
+From here on out its the standard Phoenix behavior. Start your application with `mix phx.server`
+and your API should be ready to try out. Should you be wondering what routes are available, you can
+print all available routes for each Resource:
+
+```elixir
+Helpdesk.Support.Ticket
+|> AshJsonApi.Resource.Info.routes()
+```
+
+Make sure that all requests you make to the API use the `application/vnd.api+json` type in both the
+`Accept` and `Content-Type` (where applicable) headers. The `Accept` header may be omitted.
+
+Examples:
+
+1. Create a ticket
+    ```bash
+    curl -X POST 'localhost:4000/api/json/helpdesk/tickets' \
+    --header 'Accept: application/vnd.api+json' \
+    --header 'Content-Type: application/vnd.api+json' \
+    --data-raw '{
+      "data": {
+        "type": "ticket",
+        "attributes": {
+          "subject": "This ticket was created through the JSON API"
+        }
+      }
+    }'
+    ```
+1. Get all tickets
+    ```bash
+    curl 'localhost:4000/api/json/helpdesk/tickets'
+    ```
+1. Get a specific ticket
+    ```bash
+    # Add the uuid of a Ticket you created earlier
+    curl 'localhost:4000/api/json/helpdesk/tickets/<uuid>'
+    ```

--- a/documentation/tutorials/getting-started-with-json-api.md
+++ b/documentation/tutorials/getting-started-with-json-api.md
@@ -4,7 +4,30 @@ The easiest set up involves using Phoenix, but it should be roughly the same to 
 application using only Plug. We are showing examples using Phoenix Routers.
 
 The resulting JSON APIs follow the specifications from https://jsonapi.org/.
-## Configure your Resources and API
+
+To add a JSON API, we need to do the following things:
+
+1. Add the `:ash_json_api` package to your dependencies.
+2. Add the JSON API extension to your `Ash.Resource` and `Ash.Api` modules.
+3. Tell Ash which Resource actions to via the API.
+4. Add a custom media type as specified by https://jsonapi.org/.
+5. Create a router module
+6. Make your router available in your applications main router.
+
+## Add the ash_json_api dependency
+
+In your mix.exs, add the Ash JSON API dependency:
+
+```elixir
+  defp deps do
+    [
+      # .. other dependencies
+      {:ash_json_api, "~> 0.30.1"},
+    ]
+  end
+```
+
+## Configure your Resources and API and expose actions
 
 Both your Resource and API need to use the extension for the JSON API.
 
@@ -39,25 +62,6 @@ end
 Check out the [AshJsonApi.Resource documentation on
 Hex](https://hexdocs.pm/ash_json_api/AshJsonApi.Resource.html) for more information.
 
-Now, with everything in place, we need to make the new routes available in our main Router.
-
-## Create a router
-
-Create a separate Router Module to work with your Api and Registry. It will generate the routes for
-your Resources and provide the functions you would usually have in a Controller.
-
-We will later forward requests from your Applications primary (Phoenix) Router to you Ash JSON API Router.
-
-```elixir
-defmodule HelpdeskWeb.Support.Router do
-  use AshJsonApi.Api.Router,
-    # Your Ash.Api Module
-    api: Helpdesk.Support,
-    # Your Ash.Registry Module
-    registry: Helpdesk.Support.Registry
-end
-```
-
 ## Accept json_api content type
 
 Add the following to your `config/config.exs`.
@@ -79,6 +83,23 @@ This can happen if `:mime` was already compiled before the configuration was cha
 fixed by running 
 ```
 mix deps.compile mime --force
+```
+
+## Create a router
+
+Create a separate Router Module to work with your Api and Registry. It will generate the routes for
+your Resources and provide the functions you would usually have in a Controller.
+
+We will later forward requests from your Applications primary (Phoenix) Router to you Ash JSON API Router.
+
+```elixir
+defmodule HelpdeskWeb.Support.Router do
+  use AshJsonApi.Api.Router,
+    # Your Ash.Api Module
+    api: Helpdesk.Support,
+    # Your Ash.Registry Module
+    registry: Helpdesk.Support.Registry
+end
 ```
 
 ## Add the routes from your API module(s)

--- a/documentation/tutorials/getting-started-with-json-api.md
+++ b/documentation/tutorials/getting-started-with-json-api.md
@@ -9,7 +9,7 @@ To add a JSON API, we need to do the following things:
 
 1. Add the `:ash_json_api` package to your dependencies.
 2. Add the JSON API extension to your `Ash.Resource` and `Ash.Api` modules.
-3. Tell Ash which Resource actions to via the API.
+3. Tell Ash which Resource actions expose over via the API.
 4. Add a custom media type as specified by https://jsonapi.org/.
 5. Create a router module
 6. Make your router available in your applications main router.

--- a/documentation/tutorials/getting-started-with-json-api.md
+++ b/documentation/tutorials/getting-started-with-json-api.md
@@ -9,7 +9,7 @@ To add a JSON API, we need to do the following things:
 
 1. Add the `:ash_json_api` package to your dependencies.
 2. Add the JSON API extension to your `Ash.Resource` and `Ash.Api` modules.
-3. Tell Ash which Resource actions expose over via the API.
+3. Tell Ash which Resource actions expose over the API.
 4. Add a custom media type as specified by https://jsonapi.org/.
 5. Create a router module
 6. Make your router available in your applications main router.


### PR DESCRIPTION
I just set up my first Ash based JSON API and most of the information I personally needed was available somewhere, but it was split across the getting started guide, the readm, hexdocs and Discord (and in the end I was not sure where I found which information).

I tried to improve the Getting Started guide/tutorial so that it contains all the information I feel I needed to get to a point where I could fire a request against my own API.

All examples are based on the Helpdesk example from Ash's getting started guide.