### PR TITLE
improvement: Serve schema with json content-type

### DIFF
--- a/lib/ash_json_api/api/router.ex
+++ b/lib/ash_json_api/api/router.ex
@@ -54,6 +54,12 @@ defmodule AshJsonApi.Api.Router do
           to: AshJsonApi.Controllers.Schema,
           init_opts: [api: api]
         )
+
+        match("/schema.json",
+          via: :get,
+          to: AshJsonApi.Controllers.Schema,
+          init_opts: [api: api]
+        )
       end
 
       match(_, to: AshJsonApi.Controllers.NoRouteFound)

--- a/lib/ash_json_api/controllers/schema.ex
+++ b/lib/ash_json_api/controllers/schema.ex
@@ -14,6 +14,7 @@ defmodule AshJsonApi.Controllers.Schema do
       |> Jason.encode!()
 
     conn
+    |> Plug.Conn.put_resp_content_type("application/schema+json")
     |> Plug.Conn.send_resp(200, schema)
     |> Plug.Conn.halt()
   end


### PR DESCRIPTION
This PR serves generated json schemas with the content type header `"application/schema+json"` as specified by the [json schema spec](https://json-schema.org/draft/2020-12/json-schema-core.html#section-14). 

This change also allows Firefox to pretty print the generated schema, making it more readable for us feeble humans. 

Additionally, this PR adds serving the schema from `/schema.json` ensuring non standard http clients at least have the hinting of the file extension.



### Contributor checklist

- [ ] Features include unit/acceptance tests
