### PR TITLE
Raise error when json_api route depends on non-existent relationship

### DIFF
--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -673,12 +673,20 @@ defmodule AshJsonApi.JsonSchema do
          resource
        )
        when type in [:post_to_relationship, :patch_relationship, :delete_from_relationship] do
-    resource
-    |> Ash.Resource.Info.public_relationship(relationship)
-    |> relationship_resource_identifiers()
+    case Ash.Resource.Info.public_relationship(resource, relationship) do
+      nil ->
+        raise ArgumentError, """
+        Expected resource  #{resource} to define relationship #{relationship} of type #{type}
+
+        Please verify all json_api relationship routes have relationships
+        """
+
+      other ->
+        relationship_resource_identifiers(other)
+    end
   end
 
-  defp relationship_resource_identifiers(relationship) do
+  defp relationship_resource_identifiers(relationship) when is_map(relationship) do
     %{
       "type" => "object",
       "required" => ["data"],


### PR DESCRIPTION
This PR adds an helpful error message if a JSON API Route references a non-existent relationship.

Prior to this change, errors in case of a non-existent relationship have no context for identifying the root cause of the error or the incorrectly specified relationship

### Contributor checklist

- [ ] Features include unit/acceptance tests
