### PR TITLE
fix!: Status should be a string from json:api documentation

### DIFF
--- a/lib/ash_json_api/serializer.ex
+++ b/lib/ash_json_api/serializer.ex
@@ -86,7 +86,7 @@ defmodule AshJsonApi.Serializer do
   defp serialize_one_error(error, request) do
     %{}
     |> add_if_defined(:id, error.id)
-    |> add_if_defined(:status, error.status_code)
+    |> add_if_defined(:status, to_string(error.status_code))
     |> add_if_defined(:code, error.code)
     |> add_if_defined(:title, error.title)
     |> add_if_defined(:detail, error.detail)


### PR DESCRIPTION
Currently on error responses the library returns a **status** key which is a string, violating the specification as mentioned here: https://jsonapi.org/format/#error-objects

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
