### PR TITLE
improvement: Record self linking improvements

### DIFF
--- a/lib/ash_json_api/serializer.ex
+++ b/lib/ash_json_api/serializer.ex
@@ -399,7 +399,7 @@ defmodule AshJsonApi.Serializer do
 
   defp add_one_record_self_link(links, request, %resource{} = record) do
     resource
-    |> AshJsonApi.Resource.route(%{action: :get, primary?: true})
+    |> AshJsonApi.Resource.route(%{method: :get, primary?: true})
     |> case do
       nil ->
         links

--- a/lib/ash_json_api/serializer.ex
+++ b/lib/ash_json_api/serializer.ex
@@ -399,7 +399,7 @@ defmodule AshJsonApi.Serializer do
 
   defp add_one_record_self_link(links, request, %resource{} = record) do
     resource
-    |> AshJsonApi.Resource.route(%{method: :get, primary?: true})
+    |> AshJsonApi.Resource.route(%{type: :get, primary?: true})
     |> case do
       nil ->
         links

--- a/lib/ash_json_api/test/test.ex
+++ b/lib/ash_json_api/test/test.ex
@@ -149,6 +149,45 @@ defmodule AshJsonApi.Test do
     end
   end
 
+  @doc """
+  Validate the response contains a Resource Object as per 5.2 Specification 1.0
+
+  A resource object MUST contain at least the following top-level members:
+  - id
+  - type
+
+  see: https://jsonapi.org/format/1.0/#document-resource-objects
+  """
+  defmacro assert_valid_resource_object(conn, expected_type, expected_id) do
+    quote bind_quoted: [conn: conn, expected_type: expected_type, expected_id: expected_id] do
+      assert %{
+        "data" => %{
+          "type" => ^expected_type,
+          "id" => ^expected_id
+        }
+      } = conn.resp_body
+
+      conn
+    end
+  end
+
+  defmacro assert_valid_resource_objects(conn, expected_type, expected_ids) do
+    quote bind_quoted: [conn: conn, expected_type: expected_type, expected_ids: expected_ids] do
+      assert %{
+        "data" => results
+      } = conn.resp_body
+
+      assert Enum.all?(results, fn
+        %{"type" => ^expected_type, "id" => maybe_known_id} ->
+          Enum.member?(expected_ids, maybe_known_id)
+        _ ->
+          false
+      end)
+
+      conn
+    end
+  end
+
   defmacro assert_attribute_missing(conn, attribute) do
     quote bind_quoted: [conn: conn, attribute: attribute] do
       assert %{"data" => %{"attributes" => attributes}} = conn.resp_body

--- a/test/spec_compliance/fetching_data/fetching_resources_test.exs
+++ b/test/spec_compliance/fetching_data/fetching_resources_test.exs
@@ -173,7 +173,10 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
 
     test "data does NOT exist" do
       # Create a post
-      {:ok, post} = Api.create(Post, attributes: %{name: "foo"})
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Api.create!()
 
       Api
       |> get("/posts/#{post.id}/author", status: 200)

--- a/test/spec_compliance/fetching_data/fetching_resources_test.exs
+++ b/test/spec_compliance/fetching_data/fetching_resources_test.exs
@@ -19,7 +19,7 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
 
       routes do
         base("/authors")
-        get(:read)
+        get(:read, primary?: true)
         index(:read)
       end
     end
@@ -217,5 +217,31 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
   # --------------------------
   describe "HTTP semantics" do
     # I'm not sure how to test this...
+  end
+
+  @tag :spec_may
+  # JSON:API 1.0 Specification
+  # --------------------------
+  # The optional links member within each resource object contains links related to the resource.
+  # If present, this links object MAY contain a self link that identifies the resource represented by the resource object.
+  # --------------------------
+  describe "5.2.7 Resource Links" do
+    setup do
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Api.create!()
+
+      %{author: author}
+    end
+
+    test "self link is set", %{author: author} do
+      conn = Api
+      |> get("/authors/#{author.id}", status: 200)
+
+      %{"data" => %{ "links" => %{ "self" => link_to_self } }} = conn.resp_body
+
+      assert link_to_self =~ "/authors/#{author.id}"
+    end
   end
 end

--- a/test/spec_compliance/fetching_data/fetching_resources_test.exs
+++ b/test/spec_compliance/fetching_data/fetching_resources_test.exs
@@ -108,7 +108,10 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
   describe "200 OK response" do
     test "individual resource" do
       # Create a post
-      {:ok, post} = Api.create(Post, attributes: %{name: "foo"})
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Api.create!()
 
       get(Api, "/posts/#{post.id}", status: 200)
     end
@@ -126,19 +129,19 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
   describe "resource collection primary data." do
     test "data exists" do
       # Create a post
-      {:ok, post} = Api.create(Post, attributes: %{name: "foo"})
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Api.create!()
+      post2 =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "bar"})
+        |> Api.create!()
 
-      Api
-      |> get("/posts", status: 200)
-      |> assert_data_equals([
-        %{
-          "attributes" => %{"name" => post.name},
-          "id" => post.id,
-          "links" => %{},
-          "relationships" => %{},
-          "type" => "post"
-        }
-      ])
+      conn =
+        Api
+        |> get("/posts", status: 200)
+        |> assert_valid_resource_objects("post", [post.id, post2.id])
     end
 
     test "data does NOT exist" do
@@ -156,17 +159,16 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
   describe "individual resource primary data." do
     test "data exists" do
       # Create a post
-      {:ok, post} = Api.create(Post, attributes: %{name: "foo"})
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Api.create!()
 
-      Api
-      |> get("/posts/#{post.id}", status: 200)
-      |> assert_data_equals(%{
-        "attributes" => %{"name" => post.name},
-        "id" => post.id,
-        "links" => %{},
-        "relationships" => %{},
-        "type" => "post"
-      })
+      conn =
+        Api
+        |> get("/posts/#{post.id}", status: 200)
+        |> assert_valid_resource_object("post", post.id)
+        |> assert_attribute_equals("name", post.name)
     end
 
     test "data does NOT exist" do


### PR DESCRIPTION
when requiring the backing action to be named `:get` to be able to generate the self link, it is not imediately clear why the self link does not appear in the JSON:API response. Only after some digging and understanding that I would need to implement a specific action on all my resources for them to be able to link to themselfs, I found this piece of Code.

I would like to suggest, to better utilize the default `:read` action many resources have, or any other action the end user would like to use to back their JSON:API `get` route.
The route selection filter for the self link should then only require the HTTP method to be `:get` which is in scope of this project and not enforce restrictions on the backing action name, which in my opinion should be out of scope of this project and up to the end user of the framework.

---

I'm open to feedback if this is a good or terrible idea.
As a disclaimer, I'm just getting started with ash and ash_json_api so this might not be _the way_.

### Testing

I've added a test to compliance test, as described in [5.2.7 Resource Links](https://jsonapi.org/format/1.0/#document-resource-object-links).

To see the test in action, I had to include some tags:

`mix test --trace --include skip --include json_api_spec_1_0 --include spec_may test/spec_compliance/fetching_data/fetching_resources_test.exs`

As a by product I've repaired some of the other test cases in that file to run again... I'm not too happy these changes are mixed, but could not think of a better place to include my own test case.

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
