### PR TITLE
docs: Update open-api.md

### DIFF
--- a/documentation/topics/open-api.md
+++ b/documentation/topics/open-api.md
@@ -3,7 +3,8 @@
 To set up the open api endpoints for your application, first include the `:open_api_spex` dependency:
 
 ```elixir
-{:open_api_spex, "~> 3.16"}
+{:open_api_spex, "~> 3.16"},
+{:redoc_ui_plug, "~> 0.2.1"},
 ```
 
 Then in the module where you call `use AshJsonApi.Api.Router` add the following option:
@@ -16,13 +17,13 @@ Finally, you can use utilities provided by `open_api_spex` to show UIs for your 
 
 ```elixir
 forward "/api/swaggerui",
-  OpenApiSpex.Plug.SwaggerUI,
+  to: OpenApiSpex.Plug.SwaggerUI,
   path: "/api/open_api",
   title: "Myapp's JSON-API - Swagger UI",
   default_model_expand_depth: 4
 
 forward "/api/redoc",
-  Redoc.Plug.RedocUI,
+  to: Redoc.Plug.RedocUI,
   spec_url: "/api/open_api"
 
 forward "/api", YourApp.YourApiRouter

--- a/documentation/topics/open-api.md
+++ b/documentation/topics/open-api.md
@@ -1,6 +1,40 @@
 # Open API
 
+## Use with Phoenix
+
 To set up the open api endpoints for your application, first include the `:open_api_spex` dependency:
+
+```elixir
+{:open_api_spex, "~> 3.16"},
+```
+
+Then in the module where you call `use AshJsonApi.Api.Router` add the following option:
+
+```elixir
+use AshJsonApi.Api.Router, apis: [...], open_api: "/open_api"
+```
+
+Finally, you can use utilities provided by `open_api_spex` to show UIs for your api. Be sure to put your `forward` call last, if you are putting your api at a sub-path.
+
+```elixir
+forward "/api/swaggerui",
+  OpenApiSpex.Plug.SwaggerUI,
+  path: "/api/open_api",
+  title: "Myapp's JSON-API - Swagger UI",
+  default_model_expand_depth: 4
+
+forward "/api/redoc",
+  Redoc.Plug.RedocUI,
+  spec_url: "/api/open_api"
+
+forward "/api", YourApp.YourApiRouter
+```
+
+Now you can go to `/api/swaggerui` and `/api/redoc`!
+
+## Use with Plug
+
+To set up the open api endpoints for your application, first include the `:open_api_spex` and `:redoc_ui_plug` dependency:
 
 ```elixir
 {:open_api_spex, "~> 3.16"},
@@ -18,13 +52,17 @@ Finally, you can use utilities provided by `open_api_spex` to show UIs for your 
 ```elixir
 forward "/api/swaggerui",
   to: OpenApiSpex.Plug.SwaggerUI,
-  path: "/api/open_api",
-  title: "Myapp's JSON-API - Swagger UI",
-  default_model_expand_depth: 4
+  init_opts: [
+    path: "/api/open_api",
+    title: "Myapp's JSON-API - Swagger UI",
+    default_model_expand_depth: 4
+  ]
 
 forward "/api/redoc",
   to: Redoc.Plug.RedocUI,
-  spec_url: "/api/open_api"
+  init_opts: [
+    spec_url: "/api/open_api"
+  ]
 
 forward "/api", YourApp.YourApiRouter
 ```


### PR DESCRIPTION
The `Redoc.Plug.RedocUI` is in the `{:redoc_ui_plug, "~> 0.2.1"}` package. `forward/3` does not exist so I suppose the second parameter is the `to:` option.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
