### PR TITLE
fix: Prepend slashes to relative paths

### DIFF
--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -874,6 +874,9 @@ defmodule AshJsonApi.JsonSchema do
         end
       end)
 
-    {path |> Enum.reverse() |> Path.join(), path_params}
+    {path |> Enum.reverse() |> Path.join() |> prepend_slash(), path_params}
   end
+
+  defp prepend_slash("/" <> _ = path), do: path
+  defp prepend_slash(path), do: "/" <> path
 end

--- a/test/acceptance/json_schema_test.exs
+++ b/test/acceptance/json_schema_test.exs
@@ -1,0 +1,135 @@
+defmodule Test.Acceptance.JsonSchemaTest do
+  use ExUnit.Case, async: true
+
+  defmodule Author do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [
+        AshJsonApi.Resource
+      ]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("author")
+
+      routes do
+        base("/authors")
+        get(:read)
+        index(:read)
+        patch(:update)
+      end
+    end
+
+    actions do
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id, writable?: true)
+      attribute(:name, :string)
+    end
+
+    relationships do
+      has_many(:posts, Test.Acceptance.JsonSchemaTest.Post, destination_attribute: :author_id)
+    end
+  end
+
+  defmodule Post do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [
+        AshJsonApi.Resource
+      ]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("post")
+
+      routes do
+        base("/posts")
+        get(:read)
+        index(:read)
+        post(:create, relationship_arguments: [{:id, :author}])
+      end
+    end
+
+    actions do
+      defaults([:read, :update, :destroy])
+
+      create :create do
+        primary? true
+        accept([:id, :name, :hidden])
+        argument(:author, :uuid)
+
+        change(manage_relationship(:author, type: :append_and_remove))
+      end
+    end
+
+    attributes do
+      uuid_primary_key(:id, writable?: true)
+      attribute(:name, :string, allow_nil?: false)
+      attribute(:hidden, :string)
+
+      attribute(:email, :string,
+        allow_nil?: true,
+        constraints: [
+          match: ~r/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/
+        ]
+      )
+    end
+
+    relationships do
+      belongs_to(:author, Test.Acceptance.JsonSchemaTest.Author, allow_nil?: false)
+    end
+  end
+
+  defmodule Registry do
+    use Ash.Registry
+
+    entries do
+      entry(Post)
+      entry(Author)
+    end
+  end
+
+  defmodule Blogs do
+    use Ash.Api,
+      extensions: [
+        AshJsonApi.Api
+      ]
+
+    json_api do
+      router(Test.Acceptance.JsonSchemaTest.Router)
+      log_errors?(false)
+    end
+
+    resources do
+      registry(Registry)
+    end
+  end
+
+  setup do
+    json_api = AshJsonApi.JsonSchema.generate([Blogs])
+
+    %{json_api: json_api}
+  end
+
+  describe "generate json api schema" do
+    test "prepends slashes to hrefs", %{json_api: json_api} do
+      assert Enum.all?(
+               json_api["links"],
+               fn %{"href" => href} ->
+                 # Just one slash
+                 String.starts_with?(href, "/") &&
+                   !String.starts_with?(href, "//")
+               end
+             )
+    end
+  end
+end

--- a/test/acceptance/open_api_test.exs
+++ b/test/acceptance/open_api_test.exs
@@ -136,23 +136,23 @@ defmodule Test.Acceptance.OpenApiTest do
   test "API routes are mapped to OpenAPI Operations", %{open_api_spec: %OpenApi{} = api_spec} do
     assert map_size(api_spec.paths) == 4
 
-    assert %{"authors" => _, "authors/{id}" => _, "posts" => _, "posts/{id}" => _} =
+    assert %{"/authors" => _, "/authors/{id}" => _, "/posts" => _, "/posts/{id}" => _} =
              api_spec.paths
 
-    assert %OpenApiSpex.Operation{} = api_spec.paths["authors"].get
-    assert %OpenApiSpex.Operation{} = api_spec.paths["authors/{id}"].get
-    assert %OpenApiSpex.Operation{} = api_spec.paths["authors/{id}"].patch
-    assert nil == api_spec.paths["authors"].post
+    assert %OpenApiSpex.Operation{} = api_spec.paths["/authors"].get
+    assert %OpenApiSpex.Operation{} = api_spec.paths["/authors/{id}"].get
+    assert %OpenApiSpex.Operation{} = api_spec.paths["/authors/{id}"].patch
+    assert nil == api_spec.paths["/authors"].post
 
-    assert %OpenApiSpex.Operation{} = api_spec.paths["posts"].get
-    assert %OpenApiSpex.Operation{} = api_spec.paths["posts/{id}"].get
-    assert %OpenApiSpex.Operation{} = api_spec.paths["posts"].post
-    assert nil == api_spec.paths["posts/{id}"].patch
+    assert %OpenApiSpex.Operation{} = api_spec.paths["/posts"].get
+    assert %OpenApiSpex.Operation{} = api_spec.paths["/posts/{id}"].get
+    assert %OpenApiSpex.Operation{} = api_spec.paths["/posts"].post
+    assert nil == api_spec.paths["/posts/{id}"].patch
   end
 
   describe "Index route" do
     test "filter parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].get
       %OpenApiSpex.Parameter{} = filter = operation.parameters |> Enum.find(&(&1.name == :filter))
       assert filter.in == :query
       assert filter.required == false
@@ -172,7 +172,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "sort parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].get
       %OpenApiSpex.Parameter{} = sort = operation.parameters |> Enum.find(&(&1.name == :sort))
       assert sort.in == :query
       assert sort.required == false
@@ -195,7 +195,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "page parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].get
       %OpenApiSpex.Parameter{} = page = operation.parameters |> Enum.find(&(&1.name == :page))
       assert page.in == :query
       assert page.required == false
@@ -210,7 +210,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "include parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].get
 
       %OpenApiSpex.Parameter{} =
         include = operation.parameters |> Enum.find(&(&1.name == :include))
@@ -229,7 +229,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "fields parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].get
       %OpenApiSpex.Parameter{} = fields = operation.parameters |> Enum.find(&(&1.name == :fields))
       assert fields.in == :query
       assert fields.required == false
@@ -242,13 +242,13 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "Has no request body", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].get
       refute operation.requestBody
     end
 
     @tag :focus
     test "Response body schema", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].get
       response = operation.responses[200]
       schema = response.content["application/vnd.api+json"].schema
       assert schema.type == :object
@@ -260,7 +260,7 @@ defmodule Test.Acceptance.OpenApiTest do
 
   describe "Get route" do
     test "id parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts/{id}"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts/{id}"].get
       %OpenApiSpex.Parameter{} = filter = operation.parameters |> Enum.find(&(&1.name == "id"))
       assert filter.in == :path
       assert filter.required == true
@@ -270,7 +270,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "include parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts/{id}"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts/{id}"].get
 
       %OpenApiSpex.Parameter{} =
         include = operation.parameters |> Enum.find(&(&1.name == :include))
@@ -289,7 +289,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "fields parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts/{id}"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts/{id}"].get
       %OpenApiSpex.Parameter{} = fields = operation.parameters |> Enum.find(&(&1.name == :fields))
       assert fields.in == :query
       assert fields.required == false
@@ -302,13 +302,13 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "Has no request body", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts/{id}"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts/{id}"].get
       refute operation.requestBody
     end
 
     @tag :focus
     test "Response body schema", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts/{id}"].get
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts/{id}"].get
       response = operation.responses[200]
       schema = response.content["application/vnd.api+json"].schema
       assert schema.properties.data."$ref" == "#/components/schemas/post"
@@ -317,7 +317,7 @@ defmodule Test.Acceptance.OpenApiTest do
 
   describe "Create route" do
     test "include parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].post
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].post
 
       %OpenApiSpex.Parameter{} =
         include = operation.parameters |> Enum.find(&(&1.name == :include))
@@ -336,7 +336,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "fields parameter", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].post
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].post
       %OpenApiSpex.Parameter{} = fields = operation.parameters |> Enum.find(&(&1.name == :fields))
       assert fields.in == :query
       assert fields.required == false
@@ -349,7 +349,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
 
     test "Request body schema", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].post
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].post
       %OpenApiSpex.RequestBody{} = body = operation.requestBody
       schema = body.content["application/vnd.api+json"].schema
       assert schema.properties.data.type == :object
@@ -359,7 +359,7 @@ defmodule Test.Acceptance.OpenApiTest do
 
     @tag :focus
     test "Response body schema", %{open_api_spec: %OpenApi{} = api_spec} do
-      %OpenApiSpex.Operation{} = operation = api_spec.paths["posts"].post
+      %OpenApiSpex.Operation{} = operation = api_spec.paths["/posts"].post
       response = operation.responses[200]
       schema = response.content["application/vnd.api+json"].schema
       assert schema.properties.data."$ref" == "#/components/schemas/post"


### PR DESCRIPTION
Swagger and Redoc seem both to expect a leading slash in the json `href` attribute in the `links` objects.

Swagger:
<img width="140" alt="image" src="https://user-images.githubusercontent.com/997770/231862148-80a15619-928c-4bcb-ae7e-d8717b31e24d.png">
<img width="552" alt="image" src="https://user-images.githubusercontent.com/997770/231862290-0284521c-9014-4f2c-bcdd-9fe6ad674c50.png">
<img width="688" alt="image" src="https://user-images.githubusercontent.com/997770/231862360-891e2379-0260-4632-ae7f-ed8b1124e082.png">

Redoc:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/997770/231862488-2cec6ae1-5ae1-4ed4-92f9-2116777e8224.png">
