### PR TITLE
fix(OpenApi): Don't cause a compilation failure when open_api_spex is not present.

### DIFF
--- a/lib/ash_json_api/api/router.ex
+++ b/lib/ash_json_api/api/router.ex
@@ -88,8 +88,8 @@ defmodule AshJsonApi.Api.Router do
 
       open_api_opts = AshJsonApi.Api.Router.open_api_opts(opts)
 
-      case opts[:open_api] do
-        nil ->
+      case Code.ensure_loaded?(OpenApiSpex) && opts[:open_api] do
+        falsy when falsy in [nil, false] ->
           :ok
 
         true ->

--- a/lib/ash_json_api/controllers/open_api.ex
+++ b/lib/ash_json_api/controllers/open_api.ex
@@ -1,75 +1,78 @@
-defmodule AshJsonApi.Controllers.OpenApi do
-  alias OpenApiSpex.{Info, OpenApi, SecurityScheme, Server}
-  @moduledoc false
-  def init(options) do
-    options
-  end
+if Code.ensure_loaded?(OpenApiSpex) do
+  defmodule AshJsonApi.Controllers.OpenApi do
+    alias OpenApiSpex.{Info, OpenApi, SecurityScheme, Server}
 
-  # sobelow_skip ["XSS.SendResp"]
-  def call(conn, opts) do
-    spec =
-      conn
-      |> spec(opts)
-      |> Jason.encode!(pretty: true)
-
-    conn
-    |> Plug.Conn.send_resp(200, spec)
-    |> Plug.Conn.halt()
-  end
-
-  defp modify(spec, conn, opts) do
-    case opts[:modify] do
-      modify when is_function(modify) ->
-        modify.(spec, conn, opts)
-
-      {m, f, a} ->
-        apply(m, f, [spec, conn, opts | a])
-
-      _ ->
-        spec
+    @moduledoc false
+    def init(options) do
+      options
     end
-  end
 
-  @doc false
-  def spec(conn, opts) do
-    apis = List.wrap(opts[:api] || opts[:apis])
+    # sobelow_skip ["XSS.SendResp"]
+    def call(conn, opts) do
+      spec =
+        conn
+        |> spec(opts)
+        |> Jason.encode!(pretty: true)
 
-    servers =
-      if conn.private[:phoenix_endpoint] do
-        [
-          Server.from_endpoint(conn.private.phoenix_endpoint)
-        ]
-      else
-        []
+      conn
+      |> Plug.Conn.send_resp(200, spec)
+      |> Plug.Conn.halt()
+    end
+
+    defp modify(spec, conn, opts) do
+      case opts[:modify] do
+        modify when is_function(modify) ->
+          modify.(spec, conn, opts)
+
+        {m, f, a} ->
+          apply(m, f, [spec, conn, opts | a])
+
+        _ ->
+          spec
       end
+    end
 
-    %OpenApi{
-      info: %Info{
-        title: "Open API Specification",
-        version: "1.1"
-      },
-      servers: servers,
-      paths: AshJsonApi.OpenApi.paths(apis),
-      tags: AshJsonApi.OpenApi.tags(apis),
-      components: %{
-        responses: AshJsonApi.OpenApi.responses(),
-        schemas: AshJsonApi.OpenApi.schemas(apis),
-        securitySchemes: %{
-          "api_key" => %SecurityScheme{
-            type: "apiKey",
-            description: "API Key provided in the Authorization header",
-            name: "api_key",
-            in: "header"
+    @doc false
+    def spec(conn, opts) do
+      apis = List.wrap(opts[:api] || opts[:apis])
+
+      servers =
+        if conn.private[:phoenix_endpoint] do
+          [
+            Server.from_endpoint(conn.private.phoenix_endpoint)
+          ]
+        else
+          []
+        end
+
+      %OpenApi{
+        info: %Info{
+          title: "Open API Specification",
+          version: "1.1"
+        },
+        servers: servers,
+        paths: AshJsonApi.OpenApi.paths(apis),
+        tags: AshJsonApi.OpenApi.tags(apis),
+        components: %{
+          responses: AshJsonApi.OpenApi.responses(),
+          schemas: AshJsonApi.OpenApi.schemas(apis),
+          securitySchemes: %{
+            "api_key" => %SecurityScheme{
+              type: "apiKey",
+              description: "API Key provided in the Authorization header",
+              name: "api_key",
+              in: "header"
+            }
           }
-        }
-      },
-      security: [
-        %{
-          # API Key security applies to all operations
-          "api_key" => []
-        }
-      ]
-    }
-    |> modify(conn, opts)
+        },
+        security: [
+          %{
+            # API Key security applies to all operations
+            "api_key" => []
+          }
+        ]
+      }
+      |> modify(conn, opts)
+    end
   end
 end

--- a/lib/ash_json_api/error/framework_error.ex
+++ b/lib/ash_json_api/error/framework_error.ex
@@ -1,6 +1,6 @@
 defmodule AshJsonApi.Error.FrameworkError do
   @moduledoc """
-  Returned when an unexpected error in the framework has occured.
+  Returned when an unexpected error in the framework has occurred.
   """
   @detail @moduledoc
   @title "Framework Error"


### PR DESCRIPTION
The `open_api_spex` package is set as an optional dependency, so when it's not present we need to not compile the OpenApi controller.  I considered having it return an error, but I think it's better to not include it in the routes at all if the package is missing and the server will return a 404.
