### PR TITLE
improvement: Filter for resources that have a json_api type defined

### DIFF
--- a/lib/ash_json_api/api/router.ex
+++ b/lib/ash_json_api/api/router.ex
@@ -47,7 +47,7 @@ defmodule AshJsonApi.Api.Router do
         resources = Ash.Api.Info.depend_on_resources(api)
 
         resources
-        |> Enum.filter(&(AshJsonApi.Resource in Spark.extensions(&1)))
+        |> Enum.filter(&AshJsonApi.Resource.Info.type(&1))
         |> Enum.each(fn resource ->
           for %{
                 route: route,

--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -10,7 +10,7 @@ defmodule AshJsonApi.JsonSchema do
         resources =
           api
           |> Ash.Api.Info.resources()
-          |> Enum.filter(&(AshJsonApi.Resource in Spark.extensions(&1)))
+          |> Enum.filter(&AshJsonApi.Resource.Info.type(&1))
 
         new_route_schemas =
           Enum.flat_map(resources, fn resource ->
@@ -246,7 +246,7 @@ defmodule AshJsonApi.JsonSchema do
     resource
     |> Ash.Resource.Info.public_relationships()
     |> Enum.filter(fn relationship ->
-      AshJsonApi.Resource in Spark.extensions(relationship)
+      AshJsonApi.Resource.Info.type(relationship)
     end)
     |> Enum.reduce(%{}, fn rel, acc ->
       data = resource_relationship_field_data(resource, rel)

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -162,7 +162,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resources(api) do
       api
       |> Ash.Api.Info.resources()
-      |> Enum.filter(&(AshJsonApi.Resource in Spark.extensions(&1)))
+      |> Enum.filter(&AshJsonApi.Resource.Info.type(&1))
     end
 
     @spec resource_object_schema(resource :: Ash.Resource.t()) :: Schema.t()

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -287,7 +287,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
       resource
       |> Ash.Resource.Info.public_relationships()
       |> Enum.filter(fn relationship ->
-        AshJsonApi.Resource in Spark.extensions(relationship)
+        AshJsonApi.Resource.Info.type(relationship)
       end)
       |> Map.new(fn rel ->
         data = resource_relationship_field_data(resource, rel)


### PR DESCRIPTION
Fixes a bug where included resources that don't have a json_api type show up in the top-level schema with a blank key.

```
{
  ...,
  "schemas": {
      "": {
        "additionalProperties": false,
        "description": "A \"Resource object\" representing a ", ...},
  ...
}
```