### PR TITLE
fix: Remove id from resource attributes

### DIFF
--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -221,16 +221,14 @@ defmodule AshJsonApi.JsonSchema do
   defp required_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.reject(
-      &(&1.allow_nil? || (AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
-    )
+    |> Enum.reject(&(&1.allow_nil? || AshJsonApi.Resource.only_primary_key?(resource, &1.name)))
     |> Enum.map(&to_string(&1.name))
   end
 
   defp resource_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.reject(&(AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
+    |> Enum.reject(&AshJsonApi.Resource.only_primary_key?(resource, &1.name))
     |> Enum.reduce(%{}, fn attr, acc ->
       Map.put(acc, to_string(attr.name), resource_attribute_type(attr))
     end)

--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -221,13 +221,14 @@ defmodule AshJsonApi.JsonSchema do
   defp required_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.reject(& &1.allow_nil?)
+    |> Enum.filter(& &1.allow_nil? || &1.name == :id)
     |> Enum.map(&to_string(&1.name))
   end
 
   defp resource_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
+    |> Enum.reject(& &1.name == :id)
     |> Enum.reduce(%{}, fn attr, acc ->
       Map.put(acc, to_string(attr.name), resource_attribute_type(attr))
     end)

--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -221,7 +221,7 @@ defmodule AshJsonApi.JsonSchema do
   defp required_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.filter(& &1.allow_nil? || &1.name == :id)
+    |> Enum.reject(& &1.allow_nil? || &1.name == :id)
     |> Enum.map(&to_string(&1.name))
   end
 

--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -221,14 +221,16 @@ defmodule AshJsonApi.JsonSchema do
   defp required_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.reject(&(&1.allow_nil? || &1.name == :id))
+    |> Enum.reject(
+      &(&1.allow_nil? || (AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
+    )
     |> Enum.map(&to_string(&1.name))
   end
 
   defp resource_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.reject(&(&1.name == :id))
+    |> Enum.reject(&(AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
     |> Enum.reduce(%{}, fn attr, acc ->
       Map.put(acc, to_string(attr.name), resource_attribute_type(attr))
     end)

--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -221,14 +221,14 @@ defmodule AshJsonApi.JsonSchema do
   defp required_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.reject(& &1.allow_nil? || &1.name == :id)
+    |> Enum.reject(&(&1.allow_nil? || &1.name == :id))
     |> Enum.map(&to_string(&1.name))
   end
 
   defp resource_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
-    |> Enum.reject(& &1.name == :id)
+    |> Enum.reject(&(&1.name == :id))
     |> Enum.reduce(%{}, fn attr, acc ->
       Map.put(acc, to_string(attr.name), resource_attribute_type(attr))
     end)

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -200,7 +200,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resource_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
-      |> Enum.reject(&(AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
+      |> Enum.reject(&AshJsonApi.Resource.only_primary_key?(resource, &1.name))
       |> Map.new(fn attr ->
         {attr.name, resource_attribute_type(attr)}
       end)
@@ -265,9 +265,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp required_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
-      |> Enum.reject(
-        &(&1.allow_nil? || (AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
-      )
+      |> Enum.reject(&(&1.allow_nil? || AshJsonApi.Resource.only_primary_key?(resource, &1.name)))
       |> Enum.map(& &1.name)
       |> case do
         [] -> nil

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -200,7 +200,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resource_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
-      |> Enum.reject(&(&1.name == :id))
+      |> Enum.reject(&(AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
       |> Map.new(fn attr ->
         {attr.name, resource_attribute_type(attr)}
       end)
@@ -265,7 +265,9 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp required_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
-      |> Enum.reject(&(&1.allow_nil? || &1.name == :id))
+      |> Enum.reject(
+        &(&1.allow_nil? || (AshJsonApi.Resource.reject_id?(&1.name) && &1.primary_key?))
+      )
       |> Enum.map(& &1.name)
       |> case do
         [] -> nil

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -200,6 +200,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resource_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
+      |> Enum.reject(& &1.name == :id)
       |> Map.new(fn attr ->
         {attr.name, resource_attribute_type(attr)}
       end)
@@ -264,7 +265,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp required_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
-      |> Enum.reject(& &1.allow_nil?)
+      |> Enum.reject(& &1.allow_nil? || &1.name == :id)
       |> Enum.map(& &1.name)
       |> case do
         [] -> nil

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -200,7 +200,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resource_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
-      |> Enum.reject(& &1.name == :id)
+      |> Enum.reject(&(&1.name == :id))
       |> Map.new(fn attr ->
         {attr.name, resource_attribute_type(attr)}
       end)
@@ -265,7 +265,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp required_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
-      |> Enum.reject(& &1.allow_nil? || &1.name == :id)
+      |> Enum.reject(&(&1.allow_nil? || &1.name == :id))
       |> Enum.map(& &1.name)
       |> case do
         [] -> nil

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -553,6 +553,12 @@ defmodule AshJsonApi.Resource do
     end
   end
 
-  def reject_id?(:id), do: true
-  def reject_id?(_), do: false
+  def only_primary_key?(resource, field) do
+    resource
+    |> Ash.Resource.Info.primary_key()
+    |> case do
+      [^field] -> true
+      _ -> false
+    end
+  end
 end

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -552,4 +552,16 @@ defmodule AshJsonApi.Resource do
       {:error, "Invalid fields"}
     end
   end
+
+  def reject_id?(:id), do: true
+  def reject_id?(_), do: false
+
+  def primary_key?(resource, field) do
+    resource
+    |> Ash.Resource.Info.primary_key()
+    |> case do
+      [^field] -> true
+      _ -> false
+    end
+  end
 end

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -555,13 +555,4 @@ defmodule AshJsonApi.Resource do
 
   def reject_id?(:id), do: true
   def reject_id?(_), do: false
-
-  def primary_key?(resource, field) do
-    resource
-    |> Ash.Resource.Info.primary_key()
-    |> case do
-      [^field] -> true
-      _ -> false
-    end
-  end
 end

--- a/lib/ash_json_api/serializer.ex
+++ b/lib/ash_json_api/serializer.ex
@@ -596,7 +596,7 @@ defmodule AshJsonApi.Serializer do
         default_attributes(resource)
 
     Enum.reduce(fields, %{}, fn field, acc ->
-      if AshJsonApi.Resource.reject_id?(field) do
+      if AshJsonApi.Resource.only_primary_key?(resource, field) do
         acc
       else
         field = Ash.Resource.Info.field(resource, field)

--- a/lib/ash_json_api/serializer.ex
+++ b/lib/ash_json_api/serializer.ex
@@ -596,7 +596,7 @@ defmodule AshJsonApi.Serializer do
         default_attributes(resource)
 
     Enum.reduce(fields, %{}, fn field, acc ->
-      if field == :id do
+      if AshJsonApi.Resource.reject_id?(field) do
         acc
       else
         field = Ash.Resource.Info.field(resource, field)

--- a/test/acceptance/get_test.exs
+++ b/test/acceptance/get_test.exs
@@ -140,5 +140,12 @@ defmodule Test.Acceptance.GetTest do
       |> get("/posts/#{post.id}", status: 200)
       |> assert_attribute_missing("hidden")
     end
+
+    @tag :attributes
+    test "primary keys are not rendered in attributes object", %{post: post} do
+      Api
+      |> get("/posts/#{post.id}", status: 200)
+      |> assert_attribute_missing("id")
+    end
   end
 end


### PR DESCRIPTION
`id` is currently being included in the attributes list in the schema (and is also being required), where it's otherwise being skipped during serialization: https://github.com/ash-project/ash_json_api/blob/main/lib/ash_json_api/serializer.ex#L599

The spec doesn't seem to include id in attributes, but it's definitely not required: https://jsonapi.org/format/#document-resource-objects