### PR TITLE
improvement: Add config to allow all media type params

### DIFF
--- a/lib/ash_json_api/request.ex
+++ b/lib/ash_json_api/request.ex
@@ -250,7 +250,8 @@ defmodule AshJsonApi.Request do
 
         headers ->
           Enum.any?(headers, fn {:ok, "application", "vnd.api+json", params} ->
-            valid_header_params?(params)
+            Application.get_env(:ash_json_api, :allow_all_media_type_params?, false) ||
+              valid_header_params?(params)
           end)
       end
 

--- a/test/spec_compliance/content_negotiation_test.exs
+++ b/test/spec_compliance/content_negotiation_test.exs
@@ -293,12 +293,16 @@ defmodule AshJsonApi.ContentNegotiationTest do
       )
     end
 
-    test "request Accept header is a valid media type other than JSON:API with bypass config", %{post: post} do
+    test "request Accept header is a valid media type other than JSON:API with bypass config", %{
+      post: post
+    } do
       Application.put_env(:ash_json_api, :allow_all_media_type_params?, true)
+
       get(Api, "/posts/#{post.id}",
         req_accept_header: "application/vnd.api+json; charset=\"utf-8\"",
         status: 200
       )
+
       Application.put_env(:ash_json_api, :allow_all_media_type_params?, nil)
     end
   end

--- a/test/spec_compliance/content_negotiation_test.exs
+++ b/test/spec_compliance/content_negotiation_test.exs
@@ -292,5 +292,14 @@ defmodule AshJsonApi.ContentNegotiationTest do
         status: 415
       )
     end
+
+    test "request Accept header is a valid media type other than JSON:API with bypass config", %{post: post} do
+      Application.put_env(:ash_json_api, :allow_all_media_type_params?, true)
+      get(Api, "/posts/#{post.id}",
+        req_accept_header: "application/vnd.api+json; charset=\"utf-8\"",
+        status: 200
+      )
+      Application.put_env(:ash_json_api, :allow_all_media_type_params?, nil)
+    end
   end
 end


### PR DESCRIPTION
Allows users to skip strict checking of [media type parameters](https://jsonapi.org/format/#media-type-parameters) outside of `ext` and `profile`.

This was needed as an escape hatch to Dart's largest http client automatically adding a `charset=utf8` parameter (with no ability to remove it).