### PR TITLE
Add type and descriptions

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -202,7 +202,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
       |> Ash.Resource.Info.public_attributes()
       |> Enum.reject(&AshJsonApi.Resource.only_primary_key?(resource, &1.name))
       |> Map.new(fn attr ->
-        {attr.name, resource_attribute_type(attr)}
+        {attr.name, resource_attribute_type(attr) |> with_attribute_description(attr)}
       end)
     end
 
@@ -259,6 +259,18 @@ if Code.ensure_loaded?(OpenApiSpex) do
           additionalProperties: true
         }
       end
+    end
+
+    @spec with_attribute_description(
+            Schema.t(),
+            Ash.Resource.Attribute.t() | Ash.Resource.Actions.Argument.t()
+          ) :: Schema.t()
+    defp with_attribute_description(schema, %{description: nil}) do
+      schema
+    end
+
+    defp with_attribute_description(schema, %{description: description}) do
+      %{schema | description: description}
     end
 
     @spec required_attributes(resource :: module) :: nil | [:atom]
@@ -621,7 +633,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
         resource
         |> Ash.Resource.Info.public_attributes()
         |> Map.new(fn attr ->
-          {attr.name, attribute_filter_schema(attr.type)}
+          {attr.name, attribute_filter_schema(attr.type) |> with_attribute_description(attr)}
         end)
 
       props =

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -220,6 +220,10 @@ if Code.ensure_loaded?(OpenApiSpex) do
       %Schema{type: :integer}
     end
 
+    defp resource_attribute_type(%{type: Ash.Type.Float}) do
+      %Schema{type: :number, format: :float}
+    end
+
     defp resource_attribute_type(%{type: Ash.Type.UtcDatetime}) do
       %Schema{
         type: :string,
@@ -687,6 +691,9 @@ if Code.ensure_loaded?(OpenApiSpex) do
 
           Ash.Type.Integer ->
             %Schema{type: :integer}
+
+          Ash.Type.Float ->
+            %Schema{type: :number, format: :float}
 
           Ash.Type.UtcDateTime ->
             %Schema{type: :string, format: :"date-time"}

--- a/test/acceptance/open_api_test.exs
+++ b/test/acceptance/open_api_test.exs
@@ -75,8 +75,8 @@ defmodule Test.Acceptance.OpenApiTest do
 
     attributes do
       uuid_primary_key(:id, writable?: true)
-      attribute(:name, :string, allow_nil?: false)
-      attribute(:hidden, :string)
+      attribute(:name, :string, allow_nil?: false, description: "description of attribute :name")
+      attribute(:hidden, :string, description: "description of attribute :hidden")
 
       attribute(:email, :string,
         allow_nil?: true,
@@ -197,8 +197,8 @@ defmodule Test.Acceptance.OpenApiTest do
                id: %Schema{format: :uuid, type: :string},
                author: %Schema{type: :string},
                email: %Schema{type: :string},
-               hidden: %Schema{type: :string},
-               name: %Schema{type: :string},
+               hidden: %Schema{type: :string, description: "description of attribute :hidden"},
+               name: %Schema{type: :string, description: "description of attribute :name"},
                tags: %Schema{type: :string}
              }
 
@@ -289,6 +289,40 @@ defmodule Test.Acceptance.OpenApiTest do
       assert schema.properties.data.type == :array
       assert schema.properties.data.uniqueItems == true
       assert schema.properties.data.items."$ref" == "#/components/schemas/post"
+
+      assert api_spec.components.schemas["post"] == %OpenApiSpex.Schema{
+               additionalProperties: false,
+               description: "A \"Resource object\" representing a post",
+               properties: %{
+                 attributes: %OpenApiSpex.Schema{
+                   additionalProperties: false,
+                   description: "An attributes object for a post",
+                   properties: %{
+                     email: %OpenApiSpex.Schema{type: :string},
+                     hidden: %OpenApiSpex.Schema{
+                       description: "description of attribute :hidden",
+                       type: :string
+                     },
+                     name: %OpenApiSpex.Schema{
+                       description: "description of attribute :name",
+                       type: :string
+                     }
+                   },
+                   required: [:name],
+                   type: :object
+                 },
+                 id: %{type: :string},
+                 relationships: %OpenApiSpex.Schema{
+                   additionalProperties: false,
+                   description: "A relationships object for a post",
+                   properties: %{},
+                   type: :object
+                 },
+                 type: %OpenApiSpex.Schema{type: :string}
+               },
+               required: [:type, :id],
+               type: :object
+             }
     end
   end
 


### PR DESCRIPTION
This change adds attribute descriptions to generated `OpenApiSpex.Schema`s and adds a mapping for `Ash.Type.Float`.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
