### PR TITLE
enhancement: Add `included` key with resource references in OpenAPI schema

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -964,7 +964,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
                 },
                 uniqueItems: true
               },
-              included: included_resource_schemas(resource),
+              included: included_resource_schemas(resource)
             }
           }
 
@@ -1064,7 +1064,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
       |> Enum.uniq()
     end
 
-    def relationship_destination(resource, include) do
+    defp relationship_destination(resource, include) do
       resource
       |> Ash.Resource.Info.public_relationship(include)
       |> case do

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -1043,6 +1043,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
 
     defp includes_to_resources(nil, _), do: []
     defp includes_to_resources([], _), do: []
+
     defp includes_to_resources(resource, includes) when is_list(includes) do
       includes
       |> Enum.flat_map(fn
@@ -1063,7 +1064,9 @@ if Code.ensure_loaded?(OpenApiSpex) do
       end)
       |> Enum.uniq()
     end
-    defp includes_to_resources(resource, include), do: relationship_destination(resource, include) |> List.wrap()
+
+    defp includes_to_resources(resource, include),
+      do: relationship_destination(resource, include) |> List.wrap()
 
     defp relationship_destination(resource, include) do
       resource

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -303,7 +303,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resource_relationships(resource) do
       resource
       |> Ash.Resource.Info.public_relationships()
-      |> Enum.filter(fn relationship ->
+      |> Enum.filter(fn %{destination: relationship} ->
         AshJsonApi.Resource.Info.type(relationship)
       end)
       |> Map.new(fn rel ->
@@ -963,7 +963,8 @@ if Code.ensure_loaded?(OpenApiSpex) do
                   "$ref": "#/components/schemas/#{AshJsonApi.Resource.Info.type(resource)}"
                 },
                 uniqueItems: true
-              }
+              },
+              included: included_resource_schemas(resource),
             }
           }
 
@@ -981,7 +982,8 @@ if Code.ensure_loaded?(OpenApiSpex) do
             properties: %{
               data: %Reference{
                 "$ref": "#/components/schemas/#{AshJsonApi.Resource.Info.type(resource)}"
-              }
+              },
+              included: included_resource_schemas(resource)
             }
           }
       end
@@ -1017,6 +1019,58 @@ if Code.ensure_loaded?(OpenApiSpex) do
           }
         }
       }
+    end
+
+    defp included_resource_schemas(resource) do
+      includes = AshJsonApi.Resource.Info.includes(resource)
+      include_resources = includes_to_resources(resource, includes)
+
+      include_schemas =
+        include_resources
+        |> Enum.map(fn resource ->
+          %Reference{"$ref": "#/components/schemas/#{AshJsonApi.Resource.Info.type(resource)}"}
+        end)
+
+      %Schema{
+        type: :array,
+        uniqueItems: true,
+        items: %Schema{
+          oneOf: include_schemas
+        }
+      }
+    end
+
+    defp includes_to_resources(nil, _), do: []
+    defp includes_to_resources([], _), do: []
+
+    defp includes_to_resources(resource, includes) do
+      includes
+      |> Enum.flat_map(fn
+        {include, []} ->
+          relationship_destination(resource, include) |> List.wrap()
+
+        {include, includes} ->
+          case relationship_destination(resource, include) do
+            nil ->
+              []
+
+            resource ->
+              [resource | includes_to_resources(resource, includes)]
+          end
+
+        include ->
+          relationship_destination(resource, include) |> List.wrap()
+      end)
+      |> Enum.uniq()
+    end
+
+    def relationship_destination(resource, include) do
+      resource
+      |> Ash.Resource.Info.public_relationship(include)
+      |> case do
+        %{destination: destination} -> destination
+        _ -> nil
+      end
     end
   end
 end

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -1027,6 +1027,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
 
       include_schemas =
         include_resources
+        |> Enum.filter(&AshJsonApi.Resource.Info.type(&1))
         |> Enum.map(fn resource ->
           %Reference{"$ref": "#/components/schemas/#{AshJsonApi.Resource.Info.type(resource)}"}
         end)
@@ -1042,8 +1043,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
 
     defp includes_to_resources(nil, _), do: []
     defp includes_to_resources([], _), do: []
-
-    defp includes_to_resources(resource, includes) do
+    defp includes_to_resources(resource, includes) when is_list(includes) do
       includes
       |> Enum.flat_map(fn
         {include, []} ->
@@ -1063,6 +1063,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
       end)
       |> Enum.uniq()
     end
+    defp includes_to_resources(resource, include), do: relationship_destination(resource, include) |> List.wrap()
 
     defp relationship_destination(resource, include) do
       resource

--- a/test/spec_compliance/content_negotiation_test.exs
+++ b/test/spec_compliance/content_negotiation_test.exs
@@ -203,6 +203,7 @@ defmodule AshJsonApi.ContentNegotiationTest do
       end
     end
 
+    @tag capture_log: true
     test "request Content-Type header includes two instances of JSON:API modified with a param" do
       post(Api, "/posts", @create_body,
         req_content_type_header:
@@ -217,6 +218,7 @@ defmodule AshJsonApi.ContentNegotiationTest do
       end
     end
 
+    @tag capture_log: true
     test "request Content-Type header is a valid media type other than JSON:API" do
       post(Api, "/posts", @create_body,
         req_content_type_header: "application/vnd.api+json; charset=\"utf-8\"",
@@ -264,6 +266,7 @@ defmodule AshJsonApi.ContentNegotiationTest do
       )
     end
 
+    @tag capture_log: true
     test "request Accept header includes two instances of JSON:API modified with a param", %{
       post: post
     } do
@@ -286,6 +289,7 @@ defmodule AshJsonApi.ContentNegotiationTest do
       get(Api, "/posts/#{post.id}", req_accept_header: "*/*;q=0.8", status: 200)
     end
 
+    @tag capture_log: true
     test "request Accept header is a valid media type other than JSON:API", %{post: post} do
       get(Api, "/posts/#{post.id}",
         req_accept_header: "application/vnd.api+json; charset=\"utf-8\"",

--- a/test/spec_compliance/fetching_data/fetching_resources_test.exs
+++ b/test/spec_compliance/fetching_data/fetching_resources_test.exs
@@ -139,7 +139,7 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
         |> Ash.Changeset.for_create(:create, %{name: "bar"})
         |> Api.create!()
 
-      conn =
+      _conn =
         Api
         |> get("/posts", status: 200)
         |> assert_valid_resource_objects("post", [post.id, post2.id])
@@ -165,7 +165,7 @@ defmodule AshJsonApiTest.FetchingData.FetchingResources do
         |> Ash.Changeset.for_create(:create, %{name: "foo"})
         |> Api.create!()
 
-      conn =
+      _conn =
         Api
         |> get("/posts/#{post.id}", status: 200)
         |> assert_valid_resource_object("post", post.id)


### PR DESCRIPTION
The `included` key that side loads associated records should now include public relationships added in the `json_api` `includes` key.

Also adds a fix for the `relationships` key where the schema was expecting a resource but was getting a `Ash.Resource.Relationships.*` struct instead.