### PR TITLE
Add calculated fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ ash_json_api-*.tar
 
 # Ignoring Elixir Language Server
 .elixir_ls/
+
+.elixir-tools/

--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -228,6 +228,7 @@ defmodule AshJsonApi.JsonSchema do
   defp resource_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
+    |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
     |> Enum.reject(&AshJsonApi.Resource.only_primary_key?(resource, &1.name))
     |> Enum.reduce(%{}, fn attr, acc ->
       Map.put(acc, to_string(attr.name), resource_attribute_type(attr))
@@ -482,6 +483,7 @@ defmodule AshJsonApi.JsonSchema do
     sorts =
       resource
       |> Ash.Resource.Info.public_attributes()
+      |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
       |> Enum.flat_map(fn attr -> [attr.name, "-#{attr.name}"] end)
 
     "(#{Enum.join(sorts, "|")}),*"

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -1035,7 +1035,11 @@ if Code.ensure_loaded?(OpenApiSpex) do
         end)
 
       %Schema{
-        anyOf: include_schemas
+        type: :array,
+        uniqueItems: true,
+        items: %Schema{
+          oneOf: include_schemas
+        }
       }
     end
 

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -1035,11 +1035,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
         end)
 
       %Schema{
-        type: :array,
-        uniqueItems: true,
-        items: %Schema{
-          oneOf: include_schemas
-        }
+        anyOf: include_schemas
       }
     end
 

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -200,6 +200,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resource_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
+      |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
       |> Enum.reject(&AshJsonApi.Resource.only_primary_key?(resource, &1.name))
       |> Map.new(fn attr ->
         {attr.name, resource_attribute_type(attr) |> with_attribute_description(attr)}
@@ -521,6 +522,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
       sorts =
         resource
         |> Ash.Resource.Info.public_attributes()
+        |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
         |> Enum.flat_map(fn attr -> [to_string(attr.name), "-#{attr.name}"] end)
 
       %Parameter{

--- a/lib/ash_json_api/request.ex
+++ b/lib/ash_json_api/request.ex
@@ -394,6 +394,10 @@ defmodule AshJsonApi.Request do
           fields = Map.update(request.fields, resource, [agg.name], &[agg.name | &1])
           %{request | fields: fields}
 
+        calc = Ash.Resource.Info.public_calculation(resource, key) ->
+          fields = Map.update(request.fields, resource, [calc.name], &[calc.name | &1])
+          %{request | fields: fields}
+
         true ->
           add_error(
             request,
@@ -431,6 +435,9 @@ defmodule AshJsonApi.Request do
 
           cond do
             attr = Ash.Resource.Info.public_attribute(resource, field_name) ->
+              %{request | sort: [{attr.name, order} | request.sort]}
+
+            attr = Ash.Resource.Info.public_calculation(resource, field_name) ->
               %{request | sort: [{attr.name, order} | request.sort]}
 
             agg = Ash.Resource.Info.public_aggregate(resource, field_name) ->

--- a/lib/ash_json_api/serializer.ex
+++ b/lib/ash_json_api/serializer.ex
@@ -637,6 +637,7 @@ defmodule AshJsonApi.Serializer do
   defp default_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
+    |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
     |> Enum.map(& &1.name)
   end
 

--- a/test/acceptance/get_test.exs
+++ b/test/acceptance/get_test.exs
@@ -59,6 +59,7 @@ defmodule Test.Acceptance.GetTest do
 
     calculations do
       calculate(:name_twice, :string, concat([:name, :name], "-"))
+      # calculate(:name_thrice, :string, concat([:name, :name, :name], "-"))
     end
   end
 
@@ -133,7 +134,6 @@ defmodule Test.Acceptance.GetTest do
         |> Ash.Changeset.for_create(:create, %{name: "foo", tag: "ash", profile: %{bio: "Bio"}})
         |> Ash.Changeset.force_change_attribute(:hidden, "hidden")
         |> Api.create!()
-        |> Api.load!(:name_twice)
 
       %{post: post}
     end
@@ -150,11 +150,29 @@ defmodule Test.Acceptance.GetTest do
       |> assert_attribute_equals("tag", post.tag)
     end
 
-    test "calculated fields are rendered properly", %{post: post} do
+    test "calculated fields are rendered properly in a field param", %{post: post} do
       Api
       |> get("/posts/#{post.id}?fields[post]=name_twice")
-      |> assert_attribute_equals("name_twice", post.name_twice)
+      |> assert_attribute_equals("name_twice", post.name <> "-" <> post.name)
     end
+
+    test "calculated fields are rendered properly by default", %{post: post} do
+      Api
+      |> get("/posts/#{post.id}")
+      |> assert_attribute_equals("name_twice", post.name <> "-" <> post.name)
+    end
+
+    test "calculated fields can be sorted on", %{post: post} do
+      Api
+      |> get("/posts/#{post.id}?sort=name_twice")
+      |> assert_attribute_equals("name_twice", post.name <> "-" <> post.name)
+    end
+
+    # test "calculated fields not loaded are skipped", %{post: post} do
+    #   Api
+    #   |> get("/posts/#{post.id}?fields[post]=name_thrice")
+    #   |> assert_attribute_equals("name_thrice", nil)
+    # end
 
     @tag :attributes
     test "private attributes are not rendered in the payload", %{post: post} do

--- a/test/acceptance/open_api_test.exs
+++ b/test/acceptance/open_api_test.exs
@@ -87,6 +87,10 @@ defmodule Test.Acceptance.OpenApiTest do
       )
     end
 
+    calculations do
+      calculate(:name_twice, :string, concat([:name, :name], "-"))
+    end
+
     relationships do
       belongs_to(:author, Test.Acceptance.OpenApiTest.Author, allow_nil?: false)
       has_many(:tags, Test.Acceptance.OpenApiTest.Tag, destination_attribute: :post_id)
@@ -225,7 +229,9 @@ defmodule Test.Acceptance.OpenApiTest do
                "hidden",
                "-hidden",
                "email",
-               "-email"
+               "-email",
+               "name_twice",
+               "-name_twice"
              ]
     end
 
@@ -306,7 +312,8 @@ defmodule Test.Acceptance.OpenApiTest do
                      name: %OpenApiSpex.Schema{
                        description: "description of attribute :name",
                        type: :string
-                     }
+                     },
+                     name_twice: %OpenApiSpex.Schema{type: :string}
                    },
                    required: [:name],
                    type: :object


### PR DESCRIPTION
Adds calculated fields to API responses and to OpenAPI and JSON schemas. 

This is a draft since this assumes all public calculations are loaded in the actions. We could either return `nil` for unloaded calculations or remove the keys entirely, but I haven't exactly looked into how to do either.