### PR TITLE
use phoenix endpoint if available

### DIFF
--- a/lib/ash_json_api/request.ex
+++ b/lib/ash_json_api/request.ex
@@ -70,7 +70,7 @@ defmodule AshJsonApi.Request do
       resource: resource,
       action: action,
       includes: includes.allowed,
-      url: Conn.request_url(conn),
+      url: url(conn),
       path_params: conn.path_params,
       query_params: conn.query_params,
       req_headers: conn.req_headers,
@@ -695,5 +695,13 @@ defmodule AshJsonApi.Request do
 
   defp relationship_change_value(_) do
     :error
+  end
+
+  defp url(conn) do
+    if endpoint = conn.private[:phoenix_endpoint] do
+      endpoint.url()
+    else
+      Conn.request_url(conn)
+    end
   end
 end

--- a/lib/ash_json_api/test/test.ex
+++ b/lib/ash_json_api/test/test.ex
@@ -9,12 +9,11 @@ defmodule AshJsonApi.Test do
   @schema_file "lib/ash_json_api/test/response_schema"
   @external_resource @schema_file
 
-  # @schema @schema_file |> File.read!() |> Jason.decode!() |> JsonXema.new()
-
   def get(api, path, opts \\ []) do
     result =
       :get
       |> conn(path)
+      |> maybe_set_endpoint(opts)
       |> set_accept_request_header(opts)
       |> AshJsonApi.Api.Info.router(api).call(AshJsonApi.Api.Info.router(api).init([]))
 
@@ -247,6 +246,14 @@ defmodule AshJsonApi.Test do
       true ->
         conn
         |> put_req_header("accept", "application/vnd.api+json")
+    end
+  end
+
+  defp maybe_set_endpoint(conn, opts) do
+    if endpoint = opts[:phoenix_endpoint] do
+      put_private(conn, :phoenix_endpoint, endpoint)
+    else
+      conn
     end
   end
 end

--- a/test/acceptance/links_test.exs
+++ b/test/acceptance/links_test.exs
@@ -101,10 +101,10 @@ defmodule Test.Acceptance.Links do
         |> Enum.sort()
 
       assert sorted_links == [
-               {"first", "#{TestPhoenixEndpoint.url()}?page[limit]=5"},
+               {"first", "#{TestPhoenixEndpoint.url}?page[limit]=5"},
                {"next", nil},
                {"prev", nil},
-               {"self", "#{TestPhoenixEndpoint.url()}?page[limit]=5"}
+               {"self", "#{TestPhoenixEndpoint.url}?page[limit]=5"}
              ]
     end
   end

--- a/test/acceptance/links_test.exs
+++ b/test/acceptance/links_test.exs
@@ -101,10 +101,10 @@ defmodule Test.Acceptance.Links do
         |> Enum.sort()
 
       assert sorted_links == [
-               {"first", "#{TestPhoenixEndpoint.url}?page[limit]=5"},
+               {"first", "#{TestPhoenixEndpoint.url()}?page[limit]=5"},
                {"next", nil},
                {"prev", nil},
-               {"self", "#{TestPhoenixEndpoint.url}?page[limit]=5"}
+               {"self", "#{TestPhoenixEndpoint.url()}?page[limit]=5"}
              ]
     end
   end

--- a/test/acceptance/links_test.exs
+++ b/test/acceptance/links_test.exs
@@ -1,0 +1,111 @@
+defmodule Test.Acceptance.Links do
+  use ExUnit.Case, async: true
+
+  defmodule Post do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [
+        AshJsonApi.Resource
+      ]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("post")
+
+      routes do
+        base("/posts")
+        get(:read)
+        index(:read)
+      end
+    end
+
+    actions do
+      defaults([:create, :update, :destroy])
+
+      read :read do
+        primary? true
+
+        pagination(
+          keyset?: true,
+          default_limit: 5
+        )
+      end
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string)
+
+      timestamps(private?: false)
+    end
+  end
+
+  defmodule Registry do
+    use Ash.Registry
+
+    entries do
+      entry(Post)
+    end
+  end
+
+  defmodule Api do
+    use Ash.Api,
+      extensions: [
+        AshJsonApi.Api
+      ]
+
+    json_api do
+      router(AshJsonApiTest.FetchingData.Pagination.Keyset.Router)
+    end
+
+    resources do
+      registry(Registry)
+    end
+  end
+
+  defmodule Router do
+    use AshJsonApi.Api.Router, registry: Registry, api: Api
+  end
+
+  defmodule TestPhoenixEndpoint do
+    def url() do
+      "https://test-endpoint.com"
+    end
+  end
+
+  import AshJsonApi.Test
+
+  setup do
+    posts =
+      for index <- 1..15 do
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo-#{index}"})
+        |> Api.create!()
+      end
+
+    [posts: posts]
+  end
+
+  describe "link generation" do
+    test "generates links when Phoenix Endpoint is present" do
+      conn = get(Api, "/posts", phoenix_endpoint: TestPhoenixEndpoint, status: 200)
+
+      assert %{"links" => links} = conn.resp_body
+
+      sorted_links =
+        links
+        |> Map.to_list()
+        |> Enum.sort()
+
+      assert sorted_links == [
+               {"first", "#{TestPhoenixEndpoint.url()}?page[limit]=5"},
+               {"next", nil},
+               {"prev", nil},
+               {"self", "#{TestPhoenixEndpoint.url()}?page[limit]=5"}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
## Whats new

Uses phoenix_endpoint for link url generation if present in the conn.

Fixes https://github.com/ash-project/ash_json_api/issues/94

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
