### PR TITLE
Add test to show post requests don't return calculations

### DIFF
--- a/test/acceptance/post_test.exs
+++ b/test/acceptance/post_test.exs
@@ -61,7 +61,9 @@ defmodule Test.Acceptance.PostTest do
         base("/posts")
         get(:read)
         index(:read)
-        post(:create, relationship_arguments: [:author])
+
+        #post(:create, relationship_arguments: [:author])
+        post(:create, relationship_arguments: [:author], default_fields: [:name, :email, :hidden, :name_twice])
 
         post(:accepts_email,
           upsert?: true,
@@ -107,6 +109,10 @@ defmodule Test.Acceptance.PostTest do
 
     relationships do
       belongs_to(:author, Test.Acceptance.PostTest.Author, allow_nil?: true)
+    end
+
+    calculations do
+      calculate(:name_twice, :string, concat([:name, :name], "-"))
     end
   end
 
@@ -179,7 +185,9 @@ defmodule Test.Acceptance.PostTest do
           }
         }
       })
+      |> IO.inspect
       |> assert_attribute_equals("email", nil)
+      |> assert_attribute_equals("name_twice", "Post 1-Post 1")
     end
   end
 


### PR DESCRIPTION
This adds a test that now fails due to the lack of calculations being returned after a post/create request.

I've included `default_fields` in an attempt to get this to return the field, in my main branch this is returning `#Ash.NotLoaded<:calculation>` which means that the field is being selected for serialisation, however, in this repo I can't seem to trigger the same behaviour. Instead, I'm getting no field back at all. I've tried upgrading the version of the underlying Ash framework to match my code but it doesn't seem to make a difference.

Either way, I'd distil this down to the following: _Calculated fields are not returned when post requests are completed_

This calculation works fine for a read requests by using the `preparations` macro or by using a `prepare` under the actions as expected.

Ideally, I don't want the consumer of my API to have to make a `POST` to create the record then do a read to get the calculations on it but I can live with that if it's a won't/can't fix.

The response coming back after trying to add the calculated field:

```elixir
  resp_body: %{
    "data" => %{
      "attributes" => %{
        "email" => nil,
        "hidden" => "hidden",
        "name" => "Post 1"
      },
      "id" => "13930440-a1aa-4699-bfb0-7673322dd2ef",
      "links" => %{},
      "meta" => %{},
      "relationships" => %{"author" => %{"links" => %{}, "meta" => %{}}},
      "type" => "post"
    },
    "jsonapi" => %{"version" => "1.0"},
    "links" => %{"self" => "http://www.example.com/posts"}
  },
```