### PR TITLE
add macro for asserting on links

### DIFF
--- a/lib/ash_json_api/test/test.ex
+++ b/lib/ash_json_api/test/test.ex
@@ -219,6 +219,17 @@ defmodule AshJsonApi.Test do
     end
   end
 
+  defmacro assert_equal_links(conn, expected_links) do
+    quote bind_quoted: [expected_links: expected_links, conn: conn] do
+      %{"links" => resp_links} = conn.resp_body
+
+      sorted_links = Enum.sort_by(resp_links, fn {key, _value} -> key end, :desc)
+      sorted_expected_links = Enum.sort_by(expected_links, fn {key, _value} -> key end, :desc)
+
+      assert sorted_links == sorted_expected_links
+    end
+  end
+
   defp set_content_type_request_header(conn, opts) do
     cond do
       opts[:exclude_req_content_type_header] ->

--- a/test/spec_compliance/fetching_data/pagination/keyset_test.exs
+++ b/test/spec_compliance/fetching_data/pagination/keyset_test.exs
@@ -182,18 +182,15 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Keyset do
       after_cursor = List.last(keyset.results).__metadata__.keyset
       before_cursor = List.first(keyset.results).__metadata__.keyset
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: cursor_at_post_10})}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: cursor_at_post_10})}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
+      })
     end
   end
 
@@ -242,17 +239,13 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Keyset do
 
       after_cursor = List.last(keyset.results).__metadata__.keyset
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" => nil
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" => nil
+      })
     end
 
     test "[Before] when there are no more results, prev is nil" do
@@ -288,17 +281,14 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Keyset do
 
       after_cursor = List.last(keyset.results).__metadata__.keyset
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: cursor_at_post_5})}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" => nil
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: cursor_at_post_5})}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" => nil
+      })
     end
 
     test "[Before] when there are results, prev and next are set" do
@@ -342,18 +332,15 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Keyset do
       after_cursor = List.last(keyset.results).__metadata__.keyset
       before_cursor = List.first(keyset.results).__metadata__.keyset
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: cursor_at_post_10})}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: cursor_at_post_10})}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
+      })
     end
 
     # FIX: Not sure why, but getting invalid keyset here sometimes...
@@ -396,18 +383,15 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Keyset do
       after_cursor = List.last(keyset_at_10.results).__metadata__.keyset
       before_cursor = List.first(keyset_at_10.results).__metadata__.keyset
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor_at_5})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor_at_5})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
+      })
     end
 
     test "[After] when there are no more results, next is nil" do
@@ -449,17 +433,14 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Keyset do
 
       before_cursor = List.first(keyset_at_15.results).__metadata__.keyset
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor_at_10})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "next" => nil,
-               "prev" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?#{encode_page_query(%{after: after_cursor_at_10})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "next" => nil,
+        "prev" =>
+          "http://www.example.com/posts?page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
+      })
     end
 
     test "when count is true page[count] is present in links" do
@@ -498,18 +479,16 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Keyset do
       before_cursor = List.first(keyset_at_10.results).__metadata__.keyset
       after_cursor = List.last(keyset_at_10.results).__metadata__.keyset
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[count]=true&#{encode_page_query(%{after: initial_after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?page[count]=true&#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" =>
+          "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[count]=true&#{encode_page_query(%{after: initial_after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?page[count]=true&#{encode_page_query(%{after: after_cursor})}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&#{encode_page_query(%{before: before_cursor})}&sort=-inserted_at"
+      })
     end
   end
 

--- a/test/spec_compliance/fetching_data/pagination/offset_test.exs
+++ b/test/spec_compliance/fetching_data/pagination/offset_test.exs
@@ -161,17 +161,14 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Offset do
       conn = get(Api, "/posts?sort=-inserted_at", status: 200)
 
       next_offset = offset.limit
-      assert %{"links" => links} = conn.resp_body
 
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" => nil
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" => nil
+      })
     end
   end
 
@@ -212,19 +209,15 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Offset do
 
       conn = get(Api, "/posts?sort=-inserted_at&page[size]=#{page_size}", status: 200)
 
-      assert %{"links" => links} = conn.resp_body
-
       next_offset = offset.limit
 
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" => nil
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" => nil
+      })
     end
 
     test "when there are no more results in the prev direction, prev is nil" do
@@ -240,17 +233,14 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Offset do
       conn = get(Api, "/posts?sort=-inserted_at&page[offset]=0", status: 200)
 
       next_offset = offset.limit
-      assert %{"links" => links} = conn.resp_body
 
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" => nil
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" => nil
+      })
     end
 
     test "when there are results in both directions, prev and next are set" do
@@ -271,18 +261,15 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Offset do
       next_offset = offset.offset + offset.limit
       prev_offset = offset.offset - offset.limit
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[offset]=#{prev_offset}&page[limit]=#{page_size}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[offset]=#{prev_offset}&page[limit]=#{page_size}&sort=-inserted_at"
+      })
     end
 
     test "when there are no more results in next direction and count is true, next is nil" do
@@ -305,19 +292,17 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Offset do
 
       prev_offset = offset.offset - offset.limit
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[count]=true&page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "next" => nil,
-               "last" =>
-                 "http://www.example.com/posts?page[count]=true&page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[count]=true&page[offset]=#{prev_offset}&page[limit]=#{page_size}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" =>
+          "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[count]=true&page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "next" => nil,
+        "last" =>
+          "http://www.example.com/posts?page[count]=true&page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[count]=true&page[offset]=#{prev_offset}&page[limit]=#{page_size}&sort=-inserted_at"
+      })
     end
 
     test "when there are no more results in next direction and count is false, next has an offset" do
@@ -339,18 +324,15 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Offset do
       next_offset = offset.offset + offset.limit
       prev_offset = offset.offset - offset.limit
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[offset]=#{prev_offset}&page[limit]=#{page_size}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" => "http://www.example.com/posts?page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[offset]=#{initial_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[offset]=#{prev_offset}&page[limit]=#{page_size}&sort=-inserted_at"
+      })
     end
 
     test "when count is true last link is present" do
@@ -373,20 +355,18 @@ defmodule AshJsonApiTest.FetchingData.Pagination.Offset do
       next_offset = offset.offset + offset.limit
       last_offset = offset.count - offset.limit
 
-      assert %{"links" => links} = conn.resp_body
-
-      assert links == %{
-               "first" =>
-                 "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at",
-               "self" =>
-                 "http://www.example.com/posts?page[count]=true&page[offset]=#{page_size}&page[limit]=#{page_size}&sort=-inserted_at",
-               "next" =>
-                 "http://www.example.com/posts?page[count]=true&page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "last" =>
-                 "http://www.example.com/posts?page[count]=true&page[offset]=#{last_offset}&page[limit]=#{page_size}&sort=-inserted_at",
-               "prev" =>
-                 "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at"
-             }
+      assert_equal_links(conn, %{
+        "first" =>
+          "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at",
+        "self" =>
+          "http://www.example.com/posts?page[count]=true&page[offset]=#{page_size}&page[limit]=#{page_size}&sort=-inserted_at",
+        "next" =>
+          "http://www.example.com/posts?page[count]=true&page[offset]=#{next_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "last" =>
+          "http://www.example.com/posts?page[count]=true&page[offset]=#{last_offset}&page[limit]=#{page_size}&sort=-inserted_at",
+        "prev" =>
+          "http://www.example.com/posts?page[count]=true&page[limit]=#{page_size}&sort=-inserted_at"
+      })
     end
   end
 


### PR DESCRIPTION
## Whats new

Adds a macro `assert_equal_links` that sorts and compares generated links against an expected links map

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
