### PR TITLE
added a note about swagger ui & redoc integration

### DIFF
--- a/documentation/tutorials/getting-started-with-json-api.md
+++ b/documentation/tutorials/getting-started-with-json-api.md
@@ -163,4 +163,6 @@ Examples:
     curl 'localhost:4000/api/json/helpdesk/tickets/<uuid>'
     ```
 
-**Note:** If you want to expose your API via Swagger UI or Redoc, follow [this documentation](https://ash-hq.org/docs/guides/ash_json_api/latest/topics/open-api).
+## Open API
+
+If you want to expose your API via Swagger UI or Redoc, follow [this documentation](/documentation/topics/open-api.html).

--- a/documentation/tutorials/getting-started-with-json-api.md
+++ b/documentation/tutorials/getting-started-with-json-api.md
@@ -162,3 +162,5 @@ Examples:
     # Add the uuid of a Ticket you created earlier
     curl 'localhost:4000/api/json/helpdesk/tickets/<uuid>'
     ```
+
+**Note:** If you want to expose your API via Swagger UI or Redoc, follow [this documentation](https://ash-hq.org/docs/guides/ash_json_api/latest/topics/open-api).


### PR DESCRIPTION
When I followed the tutorial, I wasn't sure how to get swagger UI working. It took me a while and some research to figure out that the UI is not exposed by default and that I need to use `open_api_spex`. I hope this small note would help future readers. 

Feel free to change the wording.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
- [x] Documentation improvement
