### PR TITLE
Allow to include/exclude null values from the JSON output

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -9,6 +9,7 @@ spark_locals_without_parens = [
   delimiter: 1,
   get: 1,
   get: 2,
+  include_nil_values?: 1,
   includes: 1,
   index: 1,
   index: 2,

--- a/documentation/dsls/DSL:-AshJsonApi.Api.cheatmd
+++ b/documentation/dsls/DSL:-AshJsonApi.Api.cheatmd
@@ -136,6 +136,26 @@ end
   </td>
 </tr>
 
+<tr>
+  <td style="text-align: left">
+    <a id="json_api-include_nil_values?" href="#json_api-include_nil_values?">
+      <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
+        include_nil_values?
+      </span>
+    </a>
+      
+  </td>
+  <td style="text-align: left">
+    <code class="inline">boolean</code>
+  </td>
+  <td style="text-align: left">
+    <code class="inline">true</code>
+  </td>
+  <td style="text-align: left" colspan=2>
+    Whether or not to include properties for values that are nil in the JSON output
+  </td>
+</tr>
+
   </tbody>
 </table>
 

--- a/documentation/dsls/DSL:-AshJsonApi.Resource.cheatmd
+++ b/documentation/dsls/DSL:-AshJsonApi.Resource.cheatmd
@@ -109,6 +109,26 @@ end
   </td>
 </tr>
 
+<tr>
+  <td style="text-align: left">
+    <a id="json_api-include_nil_values?" href="#json_api-include_nil_values?">
+      <span style="font-family: Inconsolata, Menlo, Courier, monospace;">
+        include_nil_values?
+      </span>
+    </a>
+      
+  </td>
+  <td style="text-align: left">
+    <code class="inline">`any`</code>
+  </td>
+  <td style="text-align: left">
+    
+  </td>
+  <td style="text-align: left" colspan=2>
+    Whether or not to include properties for values that are nil in the JSON output
+  </td>
+</tr>
+
   </tbody>
 </table>
 

--- a/lib/ash_json_api/api/api.ex
+++ b/lib/ash_json_api/api/api.ex
@@ -44,8 +44,7 @@ defmodule AshJsonApi.Api do
         type: :boolean,
         doc: "Whether or not to include properties for values that are nil in the JSON output",
         default: true
-      ],
- 
+      ]
     ]
   }
 

--- a/lib/ash_json_api/api/api.ex
+++ b/lib/ash_json_api/api/api.ex
@@ -39,7 +39,13 @@ defmodule AshJsonApi.Api do
         type: :boolean,
         doc: "Whether or not to log any errors produced",
         default: true
-      ]
+      ],
+      include_nil_values?: [
+        type: :boolean,
+        doc: "Whether or not to include properties for values that are nil in the JSON output",
+        default: true
+      ],
+ 
     ]
   }
 

--- a/lib/ash_json_api/api/info.ex
+++ b/lib/ash_json_api/api/info.ex
@@ -21,4 +21,8 @@ defmodule AshJsonApi.Api.Info do
   def router(api) do
     Extension.get_opt(api, [:json_api], :router, nil, false)
   end
+
+  def include_nil_values?(api) do
+    Extension.get_opt(api, [:json_api], :include_nil_values?, true, true)
+  end
 end

--- a/lib/ash_json_api/resource/info.ex
+++ b/lib/ash_json_api/resource/info.ex
@@ -26,4 +26,8 @@ defmodule AshJsonApi.Resource.Info do
   def routes(resource) do
     Extension.get_entities(resource, [:json_api, :routes])
   end
+
+  def include_nil_values?(resource) do
+    Extension.get_opt(resource, [:json_api], :include_nil_values?, nil, true)
+  end
 end

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -398,6 +398,11 @@ defmodule AshJsonApi.Resource do
         type: :any,
         default: [],
         doc: "A keyword list of all paths that are includable from this resource"
+      ],
+      include_nil_values?: [
+	type: :any,
+	default: nil,
+	doc: "Whether or not to include properties for values that are nil in the JSON output"
       ]
     ]
   }

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -400,9 +400,9 @@ defmodule AshJsonApi.Resource do
         doc: "A keyword list of all paths that are includable from this resource"
       ],
       include_nil_values?: [
-	type: :any,
-	default: nil,
-	doc: "Whether or not to include properties for values that are nil in the JSON output"
+        type: :any,
+        default: nil,
+        doc: "Whether or not to include properties for values that are nil in the JSON output"
       ]
     ]
   }

--- a/lib/ash_json_api/serializer.ex
+++ b/lib/ash_json_api/serializer.ex
@@ -675,21 +675,21 @@ defmodule AshJsonApi.Serializer do
           match?(%Ash.Resource.Calculation{}, field) &&
               match?(%Ash.NotLoaded{}, Map.get(record, field.name)) ->
             acc
-	  
+
           true ->
-	    value =
-	      if Ash.Type.embedded_type?(type) do
-		req = %{fields: %{}, route: %{}, api: request.api}
-		serialize_attributes(req, Map.get(record, field.name))
-	      else
-		Map.get(record, field.name)
-	      end
-	    
-	    if not is_nil(value) or include_nil_values?(request, record) do
+            value =
+              if Ash.Type.embedded_type?(type) do
+                req = %{fields: %{}, route: %{}, api: request.api}
+                serialize_attributes(req, Map.get(record, field.name))
+              else
+                Map.get(record, field.name)
+              end
+
+            if not is_nil(value) or include_nil_values?(request, record) do
               Map.put(acc, field.name, value)
-	    else
-	      acc
-	    end
+            else
+              acc
+            end
         end
       end
     end)

--- a/test/acceptance/include_nil_values_test.exs
+++ b/test/acceptance/include_nil_values_test.exs
@@ -1,0 +1,164 @@
+defmodule Test.Acceptance.IncludeNilValuesTest do
+  @moduledoc """
+  This test tries to assert that the following things apply:
+  - If a resource does not set include_nil_values? the serializer uses the value set for its API.
+  - If the API does not set include_nil_values? the serializer uses the default value which is true.
+  - If a resource sets include_nil_values? to false the serializer does not include nil values.
+  """
+
+  use ExUnit.Case, async: true
+
+  defmodule Include do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [
+        AshJsonApi.Resource
+      ]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("include")
+
+      routes do
+        base("/includes")
+
+        index(:read)
+      end
+    end
+
+    actions do
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:foo, :string)
+      attribute(:bar, :string)
+    end
+  end
+
+  defmodule Exclude do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [
+        AshJsonApi.Resource
+      ]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("exclude")
+
+      routes do
+        base("/excludes")
+
+        index(:read)
+      end
+
+      include_nil_values?(false)
+    end
+
+    actions do
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:foo, :string)
+      attribute(:bar, :string)
+    end
+  end
+
+  defmodule Registry do
+    use Ash.Registry
+
+    entries do
+      entry(Include)
+      entry(Exclude)
+    end
+  end
+
+  defmodule Api do
+    use Ash.Api,
+      extensions: [
+        AshJsonApi.Api
+      ]
+
+    json_api do
+      router(Test.Acceptance.IncludeNilValuesTest.Router)
+      log_errors?(false)
+    end
+
+    resources do
+      registry(Registry)
+    end
+  end
+
+  defmodule Router do
+    use AshJsonApi.Api.Router, api: Api
+  end
+
+  import AshJsonApi.Test
+
+  describe "include index endpoint" do
+    setup do
+      include =
+        Include
+        |> Ash.Changeset.for_create(:create, %{foo: "foo"})
+        |> Api.create!()
+
+      %{include: include}
+    end
+
+    test "returns a list of resources including nil values", %{include: include} do
+      Api
+      |> get("/includes", status: 200)
+      |> assert_data_equals([
+        %{
+          "attributes" => %{
+            "foo" => "foo",
+            "bar" => nil
+          },
+          "id" => include.id,
+          "links" => %{},
+          "meta" => %{},
+          "relationships" => %{},
+          "type" => "include"
+        }
+      ])
+    end
+  end
+
+  describe "exclude index endpoint" do
+    setup do
+      exclude =
+        Exclude
+        |> Ash.Changeset.for_create(:create, %{foo: "foo"})
+        |> Api.create!()
+
+      %{exclude: exclude}
+    end
+
+    test "returns a list of resources excluding nil values", %{exclude: exclude} do
+      Api
+      |> get("/excludes", status: 200)
+      |> assert_data_equals([
+        %{
+          "attributes" => %{
+            "foo" => "foo"
+          },
+          "id" => exclude.id,
+          "links" => %{},
+          "meta" => %{},
+          "relationships" => %{},
+          "type" => "exclude"
+        }
+      ])
+    end
+  end
+end


### PR DESCRIPTION
It's now possible to set `include_nil_values?` for `AshJsonApi.API` and `AshJsonApi.Resource`. If you don't set it for the API the default is `true` to make sure it does not break existing APIs. If you don't set it for a resource, it will use the value of its API.

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
