### PR TITLE
fix: bug when multiple domains are used in a router

### DIFF
--- a/lib/ash_json_api/controllers/router.ex
+++ b/lib/ash_json_api/controllers/router.ex
@@ -49,7 +49,7 @@ defmodule AshJsonApi.Controllers.Router do
           domain
           |> Ash.Domain.Info.resources()
           |> Enum.filter(&(AshJsonApi.Resource in Spark.extensions(&1)))
-          |> Enum.find_value(:error, fn resource ->
+          |> Enum.find_value(nil, fn resource ->
             case resource.json_api_match_route(conn.method, conn.path_info) do
               {:ok, route, params} ->
                 {:ok, domain, resource, route, params}

--- a/test/acceptance/router_test.exs
+++ b/test/acceptance/router_test.exs
@@ -1,0 +1,124 @@
+defmodule Test.Acceptance.RouterTest do
+  use ExUnit.Case, async: true
+
+  defmodule Person do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      domain: Test.Acceptance.RouterTest.Personnel,
+      extensions: [
+        AshJsonApi.Resource
+      ]
+
+    json_api do
+      type("person")
+
+      routes do
+        base("/people")
+        get(:read)
+        index(:read)
+        post(:create)
+      end
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :create, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, public?: true)
+    end
+  end
+
+  defmodule Personnel do
+    use Ash.Domain,
+      extensions: [
+        AshJsonApi.Domain
+      ]
+
+    json_api do
+      router(Test.Acceptance.RouterTest.Router)
+      log_errors?(false)
+    end
+
+    resources do
+      resource(Person)
+    end
+  end
+
+  defmodule Item do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      domain: Test.Acceptance.RouterTest.Inventory,
+      extensions: [
+        AshJsonApi.Resource
+      ]
+
+    json_api do
+      type("item")
+
+      routes do
+        base("/items")
+        get(:read)
+        index(:read)
+        post(:create)
+      end
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:read, :create, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, public?: true)
+    end
+  end
+
+  defmodule Inventory do
+    use Ash.Domain,
+      extensions: [
+        AshJsonApi.Domain
+      ]
+
+    json_api do
+      router(Test.Acceptance.RouterTest.Router)
+      log_errors?(false)
+    end
+
+    resources do
+      resource(Item)
+    end
+  end
+
+  defmodule Router do
+    use AshJsonApi.Router,
+      domains: [Test.Acceptance.RouterTest.Personnel, Test.Acceptance.RouterTest.Inventory],
+      json_schema: "/json_schema",
+      open_api: "/open_api"
+  end
+
+  describe "POST /people" do
+    test "is routed to the Person resource's create action" do
+      response =
+        AshJsonApi.Test.post(Test.Acceptance.RouterTest.Personnel, "/people", %{
+          data: %{type: "person", attributes: %{name: "Alice"}}
+        })
+
+      assert response.status == 201
+    end
+  end
+
+  describe "POST /items" do
+    test "is routed to the Item resource's create action" do
+      response =
+        AshJsonApi.Test.post(Test.Acceptance.RouterTest.Inventory, "/items", %{
+          data: %{type: "item", attributes: %{name: "Sword"}}
+        })
+
+      assert response.status == 201
+    end
+  end
+end


### PR DESCRIPTION
### Contributor checklist

- [X] Bug fixes include regression tests
- [X] Features include unit/acceptance tests

I noticed this bug in the new router when I added a second domain to my router. It was pretty easy to track down the source of the issue so I figured I'd just submit a PR.

Basically the issue arises because `:error` is truthy, so if this inner `Enum.find_value` returns error on the first iteration (i.e. when checking for a match in the first domain), then the whole loop will return `:error:, even though there are more domains to check. In this scenario the intended behavior should be to return `nil`.