### PR TITLE
update to ash_json_api deps version in docs.

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-json-api.md
+++ b/documentation/tutorials/getting-started-with-ash-json-api.md
@@ -21,7 +21,7 @@ In your mix.exs, add the Ash JSON API dependency:
   defp deps do
     [
       # .. other dependencies
-      {:ash_json_api, "~> 1.0.0-rc.6"},
+      {:ash_json_api, "~> 1.0"},
     ]
   end
 ```


### PR DESCRIPTION
Update documentation to use ash_json_api v1.0 instead of 1.0.0-rc6, because it was released on 10 May. 