### PR TITLE
add ability to supply custom route metadata

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -20,6 +20,7 @@ spark_locals_without_parens = [
   index: 3,
   keys: 1,
   log_errors?: 1,
+  metadata: 1,
   paginate?: 1,
   patch: 1,
   patch: 2,

--- a/documentation/dsls/DSL:-AshJsonApi.Domain.md
+++ b/documentation/dsls/DSL:-AshJsonApi.Domain.md
@@ -148,6 +148,7 @@ get :read
 | [`route`](#json_api-routes-get-route){: #json_api-routes-get-route } | `String.t` | `"/:id"` | The path of the route |
 | [`default_fields`](#json_api-routes-get-default_fields){: #json_api-routes-get-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-get-primary?){: #json_api-routes-get-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-get-metadata){: #json_api-routes-get-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -188,6 +189,7 @@ index :read
 | [`route`](#json_api-routes-index-route){: #json_api-routes-index-route } | `String.t` | `"/"` | The path of the route |
 | [`default_fields`](#json_api-routes-index-default_fields){: #json_api-routes-index-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-index-primary?){: #json_api-routes-index-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-index-metadata){: #json_api-routes-index-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -227,6 +229,7 @@ post :create
 | [`route`](#json_api-routes-post-route){: #json_api-routes-post-route } | `String.t` | `"/"` | The path of the route |
 | [`default_fields`](#json_api-routes-post-default_fields){: #json_api-routes-post-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-post-primary?){: #json_api-routes-post-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-post-metadata){: #json_api-routes-post-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 | [`relationship_arguments`](#json_api-routes-post-relationship_arguments){: #json_api-routes-post-relationship_arguments } | `list(atom \| {:id, atom})` | `[]` | Arguments to be used to edit relationships. See the [relationships guide](/documentation/topics/relationships.md) for more. |
 | [`upsert?`](#json_api-routes-post-upsert?){: #json_api-routes-post-upsert? } | `boolean` | `false` | Whether or not to use the `upsert?: true` option when calling `Ash.create/2`. |
 | [`upsert_identity`](#json_api-routes-post-upsert_identity){: #json_api-routes-post-upsert_identity } | `atom` | `false` | Which identity to use for the upsert |
@@ -271,6 +274,7 @@ patch :update
 | [`route`](#json_api-routes-patch-route){: #json_api-routes-patch-route } | `String.t` | `"/:id"` | The path of the route |
 | [`default_fields`](#json_api-routes-patch-default_fields){: #json_api-routes-patch-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-patch-primary?){: #json_api-routes-patch-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-patch-metadata){: #json_api-routes-patch-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -311,6 +315,7 @@ delete :destroy
 | [`route`](#json_api-routes-delete-route){: #json_api-routes-delete-route } | `String.t` | `"/:id"` | The path of the route |
 | [`default_fields`](#json_api-routes-delete-default_fields){: #json_api-routes-delete-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-delete-primary?){: #json_api-routes-delete-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-delete-metadata){: #json_api-routes-delete-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -351,6 +356,7 @@ related :comments, :read
 | [`route`](#json_api-routes-related-route){: #json_api-routes-related-route } | `String.t` |  | The path of the route - Defaults to /:id/[relationship_name] |
 | [`default_fields`](#json_api-routes-related-default_fields){: #json_api-routes-related-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-related-primary?){: #json_api-routes-related-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-related-metadata){: #json_api-routes-related-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -391,6 +397,7 @@ relationship :comments, :read
 | [`route`](#json_api-routes-relationship-route){: #json_api-routes-relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-relationship-default_fields){: #json_api-routes-relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-relationship-primary?){: #json_api-routes-relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-relationship-metadata){: #json_api-routes-relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -430,6 +437,7 @@ post_to_relationship :comments
 | [`route`](#json_api-routes-post_to_relationship-route){: #json_api-routes-post_to_relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-post_to_relationship-default_fields){: #json_api-routes-post_to_relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-post_to_relationship-primary?){: #json_api-routes-post_to_relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-post_to_relationship-metadata){: #json_api-routes-post_to_relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -469,6 +477,7 @@ patch_relationship :comments
 | [`route`](#json_api-routes-patch_relationship-route){: #json_api-routes-patch_relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-patch_relationship-default_fields){: #json_api-routes-patch_relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-patch_relationship-primary?){: #json_api-routes-patch_relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-patch_relationship-metadata){: #json_api-routes-patch_relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -508,6 +517,7 @@ delete_from_relationship :comments
 | [`route`](#json_api-routes-delete_from_relationship-route){: #json_api-routes-delete_from_relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-delete_from_relationship-default_fields){: #json_api-routes-delete_from_relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-delete_from_relationship-primary?){: #json_api-routes-delete_from_relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-delete_from_relationship-metadata){: #json_api-routes-delete_from_relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 

--- a/documentation/dsls/DSL:-AshJsonApi.Resource.md
+++ b/documentation/dsls/DSL:-AshJsonApi.Resource.md
@@ -141,6 +141,7 @@ get :read
 | [`route`](#json_api-routes-get-route){: #json_api-routes-get-route } | `String.t` | `"/:id"` | The path of the route |
 | [`default_fields`](#json_api-routes-get-default_fields){: #json_api-routes-get-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-get-primary?){: #json_api-routes-get-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-get-metadata){: #json_api-routes-get-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -180,6 +181,7 @@ index :read
 | [`route`](#json_api-routes-index-route){: #json_api-routes-index-route } | `String.t` | `"/"` | The path of the route |
 | [`default_fields`](#json_api-routes-index-default_fields){: #json_api-routes-index-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-index-primary?){: #json_api-routes-index-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-index-metadata){: #json_api-routes-index-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -218,6 +220,7 @@ post :create
 | [`route`](#json_api-routes-post-route){: #json_api-routes-post-route } | `String.t` | `"/"` | The path of the route |
 | [`default_fields`](#json_api-routes-post-default_fields){: #json_api-routes-post-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-post-primary?){: #json_api-routes-post-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-post-metadata){: #json_api-routes-post-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 | [`relationship_arguments`](#json_api-routes-post-relationship_arguments){: #json_api-routes-post-relationship_arguments } | `list(atom \| {:id, atom})` | `[]` | Arguments to be used to edit relationships. See the [relationships guide](/documentation/topics/relationships.md) for more. |
 | [`upsert?`](#json_api-routes-post-upsert?){: #json_api-routes-post-upsert? } | `boolean` | `false` | Whether or not to use the `upsert?: true` option when calling `Ash.create/2`. |
 | [`upsert_identity`](#json_api-routes-post-upsert_identity){: #json_api-routes-post-upsert_identity } | `atom` | `false` | Which identity to use for the upsert |
@@ -261,6 +264,7 @@ patch :update
 | [`route`](#json_api-routes-patch-route){: #json_api-routes-patch-route } | `String.t` | `"/:id"` | The path of the route |
 | [`default_fields`](#json_api-routes-patch-default_fields){: #json_api-routes-patch-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-patch-primary?){: #json_api-routes-patch-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-patch-metadata){: #json_api-routes-patch-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -300,6 +304,7 @@ delete :destroy
 | [`route`](#json_api-routes-delete-route){: #json_api-routes-delete-route } | `String.t` | `"/:id"` | The path of the route |
 | [`default_fields`](#json_api-routes-delete-default_fields){: #json_api-routes-delete-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-delete-primary?){: #json_api-routes-delete-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-delete-metadata){: #json_api-routes-delete-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -339,6 +344,7 @@ related :comments, :read
 | [`route`](#json_api-routes-related-route){: #json_api-routes-related-route } | `String.t` |  | The path of the route - Defaults to /:id/[relationship_name] |
 | [`default_fields`](#json_api-routes-related-default_fields){: #json_api-routes-related-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-related-primary?){: #json_api-routes-related-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-related-metadata){: #json_api-routes-related-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -378,6 +384,7 @@ relationship :comments, :read
 | [`route`](#json_api-routes-relationship-route){: #json_api-routes-relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-relationship-default_fields){: #json_api-routes-relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-relationship-primary?){: #json_api-routes-relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-relationship-metadata){: #json_api-routes-relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -416,6 +423,7 @@ post_to_relationship :comments
 | [`route`](#json_api-routes-post_to_relationship-route){: #json_api-routes-post_to_relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-post_to_relationship-default_fields){: #json_api-routes-post_to_relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-post_to_relationship-primary?){: #json_api-routes-post_to_relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-post_to_relationship-metadata){: #json_api-routes-post_to_relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -454,6 +462,7 @@ patch_relationship :comments
 | [`route`](#json_api-routes-patch_relationship-route){: #json_api-routes-patch_relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-patch_relationship-default_fields){: #json_api-routes-patch_relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-patch_relationship-primary?){: #json_api-routes-patch_relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-patch_relationship-metadata){: #json_api-routes-patch_relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 
@@ -492,6 +501,7 @@ delete_from_relationship :comments
 | [`route`](#json_api-routes-delete_from_relationship-route){: #json_api-routes-delete_from_relationship-route } | `String.t` |  | The path of the route -  Defaults to /:id/relationships/[relationship_name] |
 | [`default_fields`](#json_api-routes-delete_from_relationship-default_fields){: #json_api-routes-delete_from_relationship-default_fields } | `list(atom)` |  | A list of fields to be shown in the attributes of the called route |
 | [`primary?`](#json_api-routes-delete_from_relationship-primary?){: #json_api-routes-delete_from_relationship-primary? } | `boolean` | `false` | Whether or not this is the route that should be linked to by default when rendering links to this type of route |
+| [`metadata`](#json_api-routes-delete_from_relationship-metadata){: #json_api-routes-delete_from_relationship-metadata } | `(any, any, any -> any)` |  | A function to generate arbitrary top-level metadata for the JSON:API response |
 
 
 

--- a/lib/ash_json_api/controllers/delete.ex
+++ b/lib/ash_json_api/controllers/delete.ex
@@ -19,6 +19,7 @@ defmodule AshJsonApi.Controllers.Delete do
     |> Request.from(resource, action, domain, all_domains, route)
     |> Helpers.destroy_record()
     |> Helpers.fetch_includes()
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_one(conn, request, 200, request.assigns.result, request.assigns.includes)
     end)

--- a/lib/ash_json_api/controllers/delete_from_relationship.ex
+++ b/lib/ash_json_api/controllers/delete_from_relationship.ex
@@ -43,6 +43,7 @@ defmodule AshJsonApi.Controllers.DeleteFromRelationship do
     conn
     |> Request.from(options[:resource], action, domain, all_domains, route)
     |> Helpers.update_record(&Helpers.resource_identifiers(&1, argument))
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_many_relationship(conn, request, 200, relationship)
     end)

--- a/lib/ash_json_api/controllers/get.ex
+++ b/lib/ash_json_api/controllers/get.ex
@@ -19,6 +19,7 @@ defmodule AshJsonApi.Controllers.Get do
     |> Request.from(resource, action, domain, all_domains, route)
     |> Helpers.fetch_record_from_path()
     |> Helpers.fetch_includes()
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_one(conn, request, 200, request.assigns.result, request.assigns.includes)
     end)

--- a/lib/ash_json_api/controllers/get_related.ex
+++ b/lib/ash_json_api/controllers/get_related.ex
@@ -20,6 +20,7 @@ defmodule AshJsonApi.Controllers.GetRelated do
     |> Request.from(resource, action, domain, all_domains, route)
     |> Helpers.fetch_related(options[:resource])
     |> Helpers.fetch_includes()
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       case relationship.cardinality do
         :one ->

--- a/lib/ash_json_api/controllers/get_relationship.ex
+++ b/lib/ash_json_api/controllers/get_relationship.ex
@@ -19,6 +19,7 @@ defmodule AshJsonApi.Controllers.GetRelationship do
     conn
     |> Request.from(resource, action, domain, all_domains, route)
     |> Helpers.fetch_related(options[:resource])
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       case relationship do
         %{cardinality: :one} ->

--- a/lib/ash_json_api/controllers/index.ex
+++ b/lib/ash_json_api/controllers/index.ex
@@ -20,6 +20,7 @@ defmodule AshJsonApi.Controllers.Index do
     |> Helpers.fetch_pagination_parameters()
     |> Helpers.fetch_records()
     |> Helpers.fetch_includes()
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_many(
         conn,

--- a/lib/ash_json_api/controllers/patch.ex
+++ b/lib/ash_json_api/controllers/patch.ex
@@ -19,6 +19,7 @@ defmodule AshJsonApi.Controllers.Patch do
     |> Request.from(resource, action, domain, all_domains, route)
     |> Helpers.update_record()
     |> Helpers.fetch_includes()
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_one(conn, request, 200, request.assigns.result, request.assigns.includes)
     end)

--- a/lib/ash_json_api/controllers/patch_relationship.ex
+++ b/lib/ash_json_api/controllers/patch_relationship.ex
@@ -43,6 +43,7 @@ defmodule AshJsonApi.Controllers.PatchRelationship do
     conn
     |> Request.from(options[:resource], action, domain, all_domains, route)
     |> Helpers.update_record(&Helpers.resource_identifiers(&1, argument))
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_many_relationship(conn, request, 200, relationship)
     end)

--- a/lib/ash_json_api/controllers/post.ex
+++ b/lib/ash_json_api/controllers/post.ex
@@ -19,6 +19,7 @@ defmodule AshJsonApi.Controllers.Post do
     |> Request.from(resource, action, domain, all_domains, route)
     |> Helpers.create_record()
     |> Helpers.fetch_includes()
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_one(conn, request, 201, request.assigns.result, request.assigns.includes)
     end)

--- a/lib/ash_json_api/controllers/post_to_relationship.ex
+++ b/lib/ash_json_api/controllers/post_to_relationship.ex
@@ -43,6 +43,7 @@ defmodule AshJsonApi.Controllers.PostToRelationship do
     conn
     |> Request.from(options[:resource], action, domain, all_domains, route)
     |> Helpers.update_record(&Helpers.resource_identifiers(&1, argument))
+    |> Helpers.fetch_metadata()
     |> Helpers.render_or_render_errors(conn, fn request ->
       Response.render_many_relationship(conn, request, 200, relationship)
     end)

--- a/lib/ash_json_api/controllers/response.ex
+++ b/lib/ash_json_api/controllers/response.ex
@@ -33,7 +33,9 @@ defmodule AshJsonApi.Controllers.Response do
 
   # sobelow_skip ["XSS.SendResp"]
   def render_one(conn, request, status, record, includes) do
-    serialized = AshJsonApi.Serializer.serialize_one(request, record, includes)
+    meta = Map.get(request.assigns, :metadata, %{})
+
+    serialized = AshJsonApi.Serializer.serialize_one(request, record, includes, meta)
 
     send_resp(conn, status, serialized)
   end
@@ -46,11 +48,14 @@ defmodule AshJsonApi.Controllers.Response do
         paginator,
         includes
       ) do
+    meta = Map.get(request.assigns, :metadata, %{})
+
     serialized =
       AshJsonApi.Serializer.serialize_many(
         request,
         paginator,
-        includes
+        includes,
+        meta
       )
 
     send_resp(conn, status, serialized)
@@ -76,7 +81,8 @@ defmodule AshJsonApi.Controllers.Response do
         request,
         request.assigns.record_from_path,
         relationship,
-        request.assigns.result
+        request.assigns.result,
+        request.assigns.metadata
       )
 
     send_resp(conn, status, serialized)

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -20,6 +20,11 @@ defmodule AshJsonApi.Resource do
       default: false,
       doc:
         "Whether or not this is the route that should be linked to by default when rendering links to this type of route"
+    ],
+    metadata: [
+      type: {:fun, 3},
+      required: false,
+      doc: "A function to generate arbitrary top-level metadata for the JSON:API response"
     ]
   ]
 

--- a/lib/ash_json_api/resource/route.ex
+++ b/lib/ash_json_api/resource/route.ex
@@ -14,7 +14,8 @@ defmodule AshJsonApi.Resource.Route do
     :upsert?,
     :upsert_identity,
     :read_action,
-    relationship_arguments: []
+    relationship_arguments: [],
+    metadata: nil
   ]
 
   @type t :: %__MODULE__{}

--- a/lib/ash_json_api/test/test.ex
+++ b/lib/ash_json_api/test/test.ex
@@ -138,6 +138,14 @@ defmodule AshJsonApi.Test do
     end
   end
 
+  defmacro assert_meta_equals(conn, expected_meta) do
+    quote bind_quoted: [conn: conn, expected_meta: expected_meta] do
+      assert %{"meta" => ^expected_meta} = conn.resp_body
+
+      conn
+    end
+  end
+
   def assert_response_header_equals(conn, header, value) do
     assert get_resp_header(conn, header) == [value]
     conn

--- a/test/acceptance/delete_test.exs
+++ b/test/acceptance/delete_test.exs
@@ -28,7 +28,14 @@ defmodule Test.Acceptance.DeleteTest do
       routes do
         base("/posts")
 
-        delete(:destroy)
+        delete :destroy do
+          metadata(fn query, result, request ->
+            %{
+              "baz" => "bar"
+            }
+          end)
+        end
+
         index(:read)
       end
     end
@@ -96,6 +103,9 @@ defmodule Test.Acceptance.DeleteTest do
     test "delete responds with 200", %{post: post} do
       Domain
       |> delete("/posts/#{post.id}", status: 200)
+      |> assert_meta_equals(%{
+        "baz" => "bar"
+      })
     end
   end
 end

--- a/test/acceptance/get_test.exs
+++ b/test/acceptance/get_test.exs
@@ -50,7 +50,14 @@ defmodule Test.Acceptance.GetTest do
       routes do
         base("/posts")
 
-        get(:read)
+        get :read do
+          metadata(fn query, result, request ->
+            %{
+              "bar" => "baz"
+            }
+          end)
+        end
+
         get(:by_name, route: "/by_name/:name")
         get(:with_error, route: "/with_error/:id")
 
@@ -178,6 +185,9 @@ defmodule Test.Acceptance.GetTest do
     test "string attributes are rendered properly", %{post: post} do
       Domain
       |> get("/posts/#{post.id}", status: 200)
+      |> assert_meta_equals(%{
+        "bar" => "baz"
+      })
       |> assert_attribute_equals("name", post.name)
     end
 

--- a/test/acceptance/index_pagination_test.exs
+++ b/test/acceptance/index_pagination_test.exs
@@ -19,7 +19,13 @@ defmodule Test.Acceptance.IndexPaginationTest do
       routes do
         base("/posts")
 
-        index(:read)
+        index :read do
+          metadata(fn query, results, request ->
+            %{
+              "baz" => "baz"
+            }
+          end)
+        end
       end
     end
 
@@ -95,6 +101,7 @@ defmodule Test.Acceptance.IndexPaginationTest do
       response =
         Domain
         |> get("/posts?page[offset]=5&page[limit]=10", status: 200)
+        |> assert_meta_equals(%{"baz" => "baz", "page" => %{}})
 
       data = response.resp_body["data"]
       assert length(data) == 5

--- a/test/acceptance/index_test.exs
+++ b/test/acceptance/index_test.exs
@@ -19,7 +19,13 @@ defmodule Test.Acceptance.IndexTest do
       routes do
         base("/posts")
 
-        index(:read)
+        index :read do
+          metadata(fn query, results, request ->
+            %{
+              "foo" => "bar"
+            }
+          end)
+        end
       end
     end
 
@@ -87,6 +93,14 @@ defmodule Test.Acceptance.IndexTest do
           "type" => "post"
         }
       ])
+    end
+
+    test "returns custom metadata for the index endpoint" do
+      Domain
+      |> get("/posts", status: 200)
+      |> assert_meta_equals(%{
+        "foo" => "bar"
+      })
     end
 
     test "returns a list of posts names only", %{post: post} do

--- a/test/acceptance/post_test.exs
+++ b/test/acceptance/post_test.exs
@@ -35,7 +35,14 @@ defmodule Test.Acceptance.PostTest do
         base("/authors")
         get(:read)
         index(:read)
-        post :confirm_name, route: "/confirm_name"
+
+        post :confirm_name do
+          route "/confirm_name"
+
+          metadata(fn changeset, result, request ->
+            %{"bar" => "foo"}
+          end)
+        end
       end
     end
 
@@ -377,11 +384,13 @@ defmodule Test.Acceptance.PostTest do
             type: "author",
             attributes: %{
               name: "foo",
-              confirm: "bar"
+              confirm: "foo"
             }
           }
-        }
+        },
+        status: 201
       )
+      |> assert_meta_equals(%{"bar" => "foo"})
     end
   end
 end


### PR DESCRIPTION
### Contributor checklist

- [X] Bug fixes include regression tests
- [X] Features include unit/acceptance tests

👋🏻 

Coming from Discord, [thread](https://discord.com/channels/711271361523351632/711271361523351636/1246127912793673809)

The idea here is to add a `metadata` option to each route that allows users to control the top-level meta of that route:

```elixir
routes do
  index :read do
    metadata fn query, results, request ->
      %{"my" => "custom", "metadata" => "here"}
    end
  end
end
```

would result in

```json
{
  "data": <...>,
  "links": [<...>],
  "meta": {
    "my": "custom",
    "metadata": "here",
    <...any builtin metadata such as page metadata>
  }
}
```

The main part of this PR that I'm a little unsure on is how I'm grabbing the query/changeset in `helpers.ex`. It seems like each route type has its own somewhat complex custom logic in there, and I'm not 100% sure that I've gotten the correct query/changeset in each scenario. This is my first substantive contribution here so I'm very open to feedback, I'm sure there's things to improve on here!