### PR TITLE
Rename module for consistency, and remove a bit of confusing text from documentation

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-json-api.md
+++ b/documentation/tutorials/getting-started-with-ash-json-api.md
@@ -68,7 +68,7 @@ end
 
 ### Defining routes on the resource
 
-Here we show an example of defining routes on the resource. In general, we suggest
+Here we show an example of defining routes on the resource.
 
 ```elixir
 defmodule Helpdesk.Support.Ticket do

--- a/lib/ash_json_api/controllers/router.ex
+++ b/lib/ash_json_api/controllers/router.ex
@@ -96,7 +96,7 @@ defmodule AshJsonApi.Controllers.Router do
   end
 
   defp open_api_request?(conn, open_api) do
-    AshJSonApi.OpenApiSpexChecker.has_open_api?() && conn.method == "GET" &&
+    AshJsonApi.OpenApiSpexChecker.has_open_api?() && conn.method == "GET" &&
       Enum.any?(open_api, &(&1 == conn.path_info))
   end
 end

--- a/lib/ash_json_api/open_api_spex_checker.ex
+++ b/lib/ash_json_api/open_api_spex_checker.ex
@@ -1,11 +1,11 @@
 if Code.ensure_loaded?(OpenApiSpex) do
-  defmodule AshJSonApi.OpenApiSpexChecker do
+  defmodule AshJsonApi.OpenApiSpexChecker do
     @moduledoc false
     @doc false
     def has_open_api?, do: true
   end
 else
-  defmodule AshJSonApi.OpenApiSpexChecker do
+  defmodule AshJsonApi.OpenApiSpexChecker do
     @moduledoc false
 
     @doc false


### PR DESCRIPTION
This text, "In general, we suggest", seemed out of place. Like something left over from a copy/paste, or perhaps it just needs a trailing ":".
I opted to remove it.

