### PR TITLE
add documentation to clarify how json path is calculated

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-json-api.md
+++ b/documentation/tutorials/getting-started-with-ash-json-api.md
@@ -161,6 +161,14 @@ scope "/api/json" do
 end
 ```
 
+With the above configuration, the path to "get" your Tickets resource would be: `/api/json/helpdesk/tickets`, where:
+
+- "/api/json", which comes from the `scope` in the router.
+
+- "/helpdesk", which comes from the `forward` in the scope.
+
+- "/tickets", which comes from the Domain or the Resource's `json_api` configuration.
+
 ## Run your API
 
 From here on out its the standard Phoenix behavior. Start your application with `mix phx.server`


### PR DESCRIPTION
Add a bit of documentation to describe how the path to a Json api resource is calculated. Seems obvious in hindsight, but I struggled getting it right and logged [an issue (nr 154)](https://github.com/ash-project/ash_json_api/issues/154). This extra bit of documentation should help lost souls like myself.