### PR TITLE
fix: fix issue with includes being duplicated when relationships overlap

### DIFF
--- a/lib/ash_json_api/includes/includer.ex
+++ b/lib/ash_json_api/includes/includer.ex
@@ -72,6 +72,11 @@ defmodule AshJsonApi.Includes.Includer do
   end
 
   defp flatten_includes_list({related, includes_list}) do
-    {related, List.flatten(includes_list)}
+    {related,
+     includes_list
+     |> List.flatten()
+     |> Enum.uniq_by(
+       &{AshJsonApi.Resource.encode_primary_key(&1), AshJsonApi.Resource.Info.type(&1)}
+     )}
   end
 end

--- a/test/acceptance/nested_include_test.exs
+++ b/test/acceptance/nested_include_test.exs
@@ -68,24 +68,32 @@ defmodule Test.Acceptance.NestedIncludeTest do
   import AshJsonApi.Test
 
   setup do
-    include =
+    include_1 =
       Include
       |> Ash.Changeset.for_create(:create, %{})
       |> Ash.create!()
 
-    include =
+    include_2 =
       Include
       |> Ash.Changeset.for_create(:create, %{})
-      |> Ash.Changeset.manage_relationship(:include_a, include, type: :append_and_remove)
-      |> Ash.Changeset.manage_relationship(:include_b, include, type: :append_and_remove)
+      |> Ash.Changeset.manage_relationship(:include_a, include_1, type: :append_and_remove)
+      |> Ash.Changeset.manage_relationship(:include_b, include_1, type: :append_and_remove)
+      |> Ash.create!()
 
-    %{include: include}
+    %{include_1: include_1, include_2: include_2}
   end
 
-  test "returns includes successfully", %{include: _include} do
-    Domain
-    |> get("/includes?include=include_a.include_a.include_a,include_b.include_b.include_b",
-      status: 200
-    )
+  test "returns includes successfully", %{include_1: %{id: include_1_id}} do
+    conn =
+      Domain
+      |> get("/includes?include=include_a.include_a.include_a,include_b.include_b.include_b",
+        status: 200
+      )
+
+    response = conn.resp_body
+
+    assert [
+             %{"id" => ^include_1_id}
+           ] = response["included"]
   end
 end


### PR DESCRIPTION
I noticed this issue with includes, which it turns out an existing test was already replicating, although there were no asserts in that test, so it wasn't getting caught.

Basically, if multiple different items in the response are all related to the same related resource, then that resource will show up multiple times in the `included` array.

In certain scenarios, this can cause response sizes to balloon pretty dramatically. In an example in my own application, I was including across a `belongs_to` and a `has_many`, and the response had ~30k elements in the `includes`, but after collapsing down to unique elements, there are actually only ~2100 unique elements.

The solution here is to get unique values by type + id in the includes list, while merging linkages from the distinct elements.

### Contributor checklist

- [X] Bug fixes include regression tests
- [X] Features include unit/acceptance tests
