### PR TITLE
Add operationId to the OpenAPI spec

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -535,6 +535,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
       end
 
       %Operation{
+        operationId: operation_id(action, resource),
         description: action_description(action, resource),
         tags: [to_string(AshJsonApi.Resource.Info.type(resource))],
         parameters: path_parameters(path_params, action) ++ query_parameters(route, resource),
@@ -551,6 +552,10 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp action_description(action, resource) do
       action.description ||
         "#{action.name} operation on #{AshJsonApi.Resource.Info.type(resource)} resource"
+    end
+
+    defp operation_id(action, resource) do
+      "#{action.name}_#{to_string(AshJsonApi.Resource.Info.type(resource))}"
     end
 
     @spec path_parameters(path_params :: [String.t()], action :: Actions.action()) ::


### PR DESCRIPTION
Took a quick look at this and the naive implementation is very simple. This implementation work fine for my use case but I'm not sure how well it would scale to far more complicated API specs. 

Is the combination of action name and resource unique? If not, what would make this unique? 

Also, if we wanted to allow people to specify the `operationId` themselves, how would I add an option to the `json_api` / `routes` definitions. I'm not really up to speed with the Spark DSL yet. 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
