### PR TITLE
fix: Don't need to use arguments in fetch query

### DIFF
--- a/lib/ash_json_api/controllers/helpers.ex
+++ b/lib/ash_json_api/controllers/helpers.ex
@@ -365,7 +365,7 @@ defmodule AshJsonApi.Controllers.Helpers do
          |> Ash.Query.set_context(request.context)
          |> Ash.Query.for_read(
            action,
-           Map.merge(request.arguments, params),
+           params,
            Keyword.put(Request.opts(request), :page, false)
          )
          |> Ash.Query.limit(1)}


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

When performing a patch/delete request, the arguments for the action that aren't present in the attributes for the resource raise an `InvalidInput` error on the read that precedes the actual update/destroy.