### PR TITLE
feat: Use resource descriptions in generated schema files if present

### DIFF
--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -116,7 +116,8 @@ defmodule AshJsonApi.JsonSchema do
   def resource_object_schema(resource) do
     %{
       "description" =>
-        "A \"Resource object\" representing a #{AshJsonApi.Resource.Info.type(resource)}",
+        Ash.Resource.Info.description(resource) ||
+          "A \"Resource object\" representing a #{AshJsonApi.Resource.Info.type(resource)}",
       "type" => "object",
       "required" => ["type", "id"],
       "properties" => %{

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -168,7 +168,8 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp resource_object_schema(resource, fields \\ nil) do
       %Schema{
         description:
-          "A \"Resource object\" representing a #{AshJsonApi.Resource.Info.type(resource)}",
+          Ash.Resource.Info.description(resource) ||
+            "A \"Resource object\" representing a #{AshJsonApi.Resource.Info.type(resource)}",
         type: :object,
         required: [:type, :id],
         properties: %{

--- a/test/acceptance/open_api_test.exs
+++ b/test/acceptance/open_api_test.exs
@@ -19,6 +19,10 @@ defmodule Test.Acceptance.OpenApiTest do
         AshJsonApi.Resource
       ]
 
+    resource do
+      description("This is an author!")
+    end
+
     ets do
       private?(true)
     end
@@ -195,6 +199,18 @@ defmodule Test.Acceptance.OpenApiTest do
   test "resources without a json_api are not included in the schema", %{open_api_spec: api_spec} do
     schema_keys = api_spec.components.schemas |> Map.keys()
     assert "tags" not in schema_keys
+  end
+
+  test "resource descriptions are used in the generated specification if provided", %{
+    open_api_spec: api_spec
+  } do
+    # The default description
+    post = api_spec.components.schemas["post"]
+    assert post.description == "A \"Resource object\" representing a post"
+
+    # A custom description read from the resource
+    author = api_spec.components.schemas["author"]
+    assert author.description == "This is an author!"
   end
 
   test "API routes are mapped to OpenAPI Operations", %{open_api_spec: %OpenApi{} = api_spec} do


### PR DESCRIPTION
Resources let you define a description, meant to be [used in generated documentation](https://hexdocs.pm/ash/dsl-ash-resource.html#resource-description), so I thought it would be cool to use it (if provided) when generating schema files!

Makes Swagger UI documentation from OpenAPI schema files approximately 1.8% more awesome.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
