### PR TITLE
feat: add support for calculation inputs via field_inputs query param

### DIFF
--- a/lib/ash_json_api/controllers/helpers.ex
+++ b/lib/ash_json_api/controllers/helpers.ex
@@ -425,13 +425,13 @@ defmodule AshJsonApi.Controllers.Helpers do
 
           query =
             query
-            |> Ash.Query.load(fields_to_load)
-            |> Ash.Query.set_context(request.context)
             |> Ash.Query.for_read(
               action,
               Map.merge(request.arguments, params),
               Keyword.put(Request.opts(request), :page, false)
             )
+            |> Ash.Query.load(fields_to_load)
+            |> Ash.Query.set_context(request.context)
 
           request = Request.assign(request, :query, query)
 
@@ -511,7 +511,15 @@ defmodule AshJsonApi.Controllers.Helpers do
   end
 
   defp fields(request, resource) do
-    Map.get(request.fields, resource) || request.route.default_fields || []
+    fields = Map.get(request.fields, resource) || request.route.default_fields || []
+    field_inputs = request.field_inputs[resource] || %{}
+
+    Enum.map(fields, fn field ->
+      case Map.get(field_inputs, field) do
+        nil -> field
+        value -> {field, value}
+      end
+    end)
   end
 
   defp default_sort(resource) do

--- a/lib/ash_json_api/controllers/helpers.ex
+++ b/lib/ash_json_api/controllers/helpers.ex
@@ -425,13 +425,13 @@ defmodule AshJsonApi.Controllers.Helpers do
 
           query =
             query
+            |> Ash.Query.set_context(request.context)
             |> Ash.Query.for_read(
               action,
               Map.merge(request.arguments, params),
               Keyword.put(Request.opts(request), :page, false)
             )
             |> Ash.Query.load(fields_to_load)
-            |> Ash.Query.set_context(request.context)
 
           request = Request.assign(request, :query, query)
 

--- a/test/acceptance/get_related_test.exs
+++ b/test/acceptance/get_related_test.exs
@@ -52,6 +52,18 @@ defmodule Test.Acceptance.GetRelatedTest do
         public?(true)
       end
     end
+
+    calculations do
+      calculate :name_twice, :string, concat([:name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
+        public?(true)
+      end
+
+      calculate :name_tripled, :string, concat([:name, :name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
+        public?(true)
+      end
+    end
   end
 
   defmodule Comment do
@@ -85,6 +97,18 @@ defmodule Test.Acceptance.GetRelatedTest do
 
     relationships do
       belongs_to(:post, Post) do
+        public?(true)
+      end
+    end
+
+    calculations do
+      calculate :name_twice, :string, concat([:name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
+        public?(true)
+      end
+
+      calculate :name_tripled, :string, concat([:name, :name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
         public?(true)
       end
     end
@@ -188,6 +212,40 @@ defmodule Test.Acceptance.GetRelatedTest do
       assert [
                %{
                  "attributes" => %{"content" => "parent", "name" => "parent"},
+                 "type" => "post"
+               }
+             ] = includes
+    end
+
+    test "field_inputs can be supplied on includes", %{post: post} do
+      includes =
+        Domain
+        |> get(
+          "/posts/#{post.id}/comments?include=post&fields[post]=name_twice&field_inputs[post][name_twice][separator]=baz",
+          status: 200
+        )
+        |> assert_data_matches([
+          %{
+            "attributes" => %{
+              "name" => "comment" <> _,
+              "content" => "comment"
+            },
+            "type" => "comment"
+          },
+          %{
+            "attributes" => %{
+              "name" => "comment" <> _,
+              "content" => "comment"
+            },
+            "type" => "comment"
+          }
+        ])
+        |> Map.get(:resp_body)
+        |> get_in(["included"])
+
+      assert [
+               %{
+                 "attributes" => %{"name_twice" => "parentbazparent"},
                  "type" => "post"
                }
              ] = includes

--- a/test/acceptance/index_test.exs
+++ b/test/acceptance/index_test.exs
@@ -46,6 +46,18 @@ defmodule Test.Acceptance.IndexTest do
       attribute(:content, :string, public?: true)
       attribute(:not_present_by_default, :string, public?: true)
     end
+
+    calculations do
+      calculate :name_twice, :string, concat([:name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
+        public?(true)
+      end
+
+      calculate :name_tripled, :string, concat([:name, :name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
+        public?(true)
+      end
+    end
   end
 
   defmodule Domain do
@@ -139,6 +151,28 @@ defmodule Test.Acceptance.IndexTest do
         %{
           "attributes" => %{
             "name" => "foo"
+          },
+          "id" => post.id,
+          "links" => %{},
+          "meta" => %{},
+          "relationships" => %{},
+          "type" => "post"
+        }
+      ])
+    end
+
+    test "accepts field_inputs as query params", %{post: post} do
+      Domain
+      |> get(
+        "/posts?field_inputs[post][name_twice][separator]=sep&fields=name,name_twice,name_tripled",
+        status: 200
+      )
+      |> assert_data_equals([
+        %{
+          "attributes" => %{
+            "name" => "foo",
+            "name_twice" => "foosepfoo",
+            "name_tripled" => "foo-foo-foo"
           },
           "id" => post.id,
           "links" => %{},

--- a/test/acceptance/nested_include_test.exs
+++ b/test/acceptance/nested_include_test.exs
@@ -193,11 +193,7 @@ defmodule Test.Acceptance.NestedIncludeTest do
     assert Enum.all?(children, fn child -> Enum.member?(included_ids, child.id) end)
   end
 
-  test "returns includes with calculations and accepts calculation arguments", %{
-    include_1: %{id: include_1_id},
-    children: children,
-    grandchild: %{id: grandchild_id}
-  } do
+  test "returns includes with calculations and accepts calculation arguments" do
     conn =
       Domain
       |> get(

--- a/test/acceptance/patch_test.exs
+++ b/test/acceptance/patch_test.exs
@@ -143,6 +143,13 @@ defmodule Test.Acceptance.PatchTest do
     relationships do
       belongs_to(:author, Test.Acceptance.PatchTest.Author, public?: true)
     end
+
+    calculations do
+      calculate :name_twice, :string, concat([:name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
+        public?(true)
+      end
+    end
   end
 
   defmodule Domain do
@@ -190,9 +197,15 @@ defmodule Test.Acceptance.PatchTest do
 
     test "patch working properly", %{post: post} do
       Domain
-      |> patch("/posts/#{post.id}", %{data: %{attributes: %{email: "dummy@test.com"}}})
+      |> patch(
+        "/posts/#{post.id}?field_inputs[post][name_twice][separator]=baz&fields[post]=email,name_twice",
+        %{
+          data: %{attributes: %{email: "dummy@test.com"}}
+        }
+      )
       |> assert_meta_equals(%{"bar" => "bar"})
       |> assert_attribute_equals("email", "dummy@test.com")
+      |> assert_attribute_equals("name_twice", "Valid PostbazValid Post")
     end
 
     @tag :attributes

--- a/test/acceptance/post_test.exs
+++ b/test/acceptance/post_test.exs
@@ -146,7 +146,10 @@ defmodule Test.Acceptance.PostTest do
     end
 
     calculations do
-      calculate(:name_twice, :string, concat([:name, :name], "-"), public?: true)
+      calculate :name_twice, :string, concat([:name, :name], arg(:separator)) do
+        argument(:separator, :string, default: "-")
+        public?(true)
+      end
     end
   end
 
@@ -201,7 +204,7 @@ defmodule Test.Acceptance.PostTest do
       id = Ecto.UUID.generate()
 
       Domain
-      |> post("/posts", %{
+      |> post("/posts?field_inputs[post][name_twice][separator]=bar", %{
         data: %{
           type: "post",
           attributes: %{
@@ -212,7 +215,7 @@ defmodule Test.Acceptance.PostTest do
         }
       })
       |> assert_attribute_equals("email", nil)
-      |> assert_attribute_equals("name_twice", "Post 1-Post 1")
+      |> assert_attribute_equals("name_twice", "Post 1barPost 1")
     end
 
     test "create with unknown input in embed generates correct error code" do


### PR DESCRIPTION
see convo [here](https://discord.com/channels/711271361523351632/711271361523351636/1245473215623725106) for context. Essentially this provides a way to supply calculation arguments via a `field_inputs` query param.

### Contributor checklist

- [X] Bug fixes include regression tests
- [X] Features include unit/acceptance tests
