### PR TITLE
fix: add leading slash to JSON pointer in schema errors

### DIFF
--- a/lib/ash_json_api/error/schema_errors.ex
+++ b/lib/ash_json_api/error/schema_errors.ex
@@ -19,7 +19,7 @@ defmodule AshJsonApi.Error.SchemaErrors do
   defp format_path_name(:parameter, []), do: ""
 
   defp format_path_name(:json_pointer, path) do
-    Enum.join(path, "/")
+    "/" <> Enum.join(path, "/")
   end
 
   defp error_messages(reason, path, acc \\ [])

--- a/test/acceptance/patch_test.exs
+++ b/test/acceptance/patch_test.exs
@@ -372,6 +372,7 @@ defmodule Test.Acceptance.PatchTest do
 
       assert %{"errors" => [error]} = response.resp_body
       assert error["code"] == "invalid_body"
+      assert error["source"] == %{"pointer" => "/data/attributes/hidden"}
 
       assert error["detail"] ==
                "Expected only defined properties, got key [\"data\", \"attributes\", \"hidden\"]."

--- a/test/acceptance/post_test.exs
+++ b/test/acceptance/post_test.exs
@@ -416,6 +416,7 @@ defmodule Test.Acceptance.PostTest do
       # response is a Plug.
       assert %{"errors" => [error]} = response.resp_body
       assert error["code"] == "invalid_body"
+      assert error["source"] == %{"pointer" => "/data/attributes/email"}
 
       assert error["detail"] ==
                "Expected only defined properties, got key [\"data\", \"attributes\", \"email\"]."
@@ -486,6 +487,7 @@ defmodule Test.Acceptance.PostTest do
       # response is a Plug.
       assert %{"errors" => [error]} = response.resp_body
       assert error["code"] == "invalid_body"
+      assert error["source"] == %{"pointer" => "/data/attributes/email"}
 
       assert error["detail"] ==
                "Expected only defined properties, got key [\"data\", \"attributes\", \"email\"]."


### PR DESCRIPTION
Be compliant with the JSON:API spec

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
