### PR TITLE
Support generating OpenAPI spec files with Mix tasks

### DIFF
--- a/documentation/topics/open-api.md
+++ b/documentation/topics/open-api.md
@@ -20,7 +20,6 @@ Finally, you can use utilities provided by `open_api_spex` to show UIs for your 
 forward "/api/swaggerui",
   OpenApiSpex.Plug.SwaggerUI,
   path: "/api/open_api",
-  title: "Myapp's JSON-API - Swagger UI",
   default_model_expand_depth: 4
 
 forward "/api/redoc",
@@ -54,7 +53,6 @@ forward "/api/swaggerui",
   to: OpenApiSpex.Plug.SwaggerUI,
   init_opts: [
     path: "/api/open_api",
-    title: "Myapp's JSON-API - Swagger UI",
     default_model_expand_depth: 4
   ]
 

--- a/documentation/topics/open-api.md
+++ b/documentation/topics/open-api.md
@@ -71,6 +71,28 @@ Now you can go to `/api/swaggerui` and `/api/redoc`!
 
 ## Customize values in the OpenAPI documentation
 
+To customize the main values of the OpenAPI spec, a few options are available:
+
+```elixir
+  use AshJsonApi.Router,
+    domains: [...],
+    open_api: "/open_api",
+    open_api_title: "Title",
+    open_api_version: "1.0.0",
+    open_api_servers: ["http://domain.com/api/v1"]
+```
+
+If `:open_api_servers` is not specified, a default server is automatically derived from your app's Phoenix endpoint, as retrieved from inbound connections on the `open_api` HTTP route.
+
+In case an active connection is not available, for example when generating the OpenAPI spec via CLI, you can explicitely specify a reference to the Phoenix endpoint:
+
+```elixir
+  use AshJsonApi.Router,
+    domains: [...],
+    open_api: "/open_api",
+    phoenix_endpoint: MyAppWeb.Endpoint
+```
+
 To override any value in the OpenApi documentation you can use the `:modify_open_api` options key:
 
 ```elixir
@@ -85,6 +107,35 @@ To override any value in the OpenApi documentation you can use the `:modify_open
       | info: %{spec.info | title: "MyApp Title JSON API", version: Application.spec(:my_app, :vsn) |> to_string()}
     }
   end
+```
+
+## Generate spec files via CLI
+
+You can write the OpenAPI spec file to disk using the Mix tasks provided by [OpenApiSpex](https://github.com/open-api-spex/open_api_spex).
+
+Supposing you have setup AshJsonApi as:
+
+```elixir
+defmodule MyAppWeb.AshJsonApi
+  use AshJsonApi.Router, domains: [...], open_api: "/open_api"
+end
+```
+
+you can generate the files with:
+
+```sh
+mix openapi.spec.json --spec MyAppWeb.AshJsonApi
+mix openapi.spec.yaml --spec MyAppWeb.AshJsonApi
+```
+
+To generate the YAML file you need to add the ymlr dependency.
+
+```elixir
+def deps do
+  [
+    {:ymlr, "~> 2.0"}
+  ]
+end
 ```
 
 ## Known issues/limitations

--- a/lib/ash_json_api/controllers/router.ex
+++ b/lib/ash_json_api/controllers/router.ex
@@ -37,9 +37,7 @@ defmodule AshJsonApi.Controllers.Router do
         AshJsonApi.Controllers.Schema.call(conn, domains: domains)
 
       open_api_request?(conn, open_api) ->
-        open_api_opts = open_api_opts(opts)
-
-        apply(AshJsonApi.Controllers.OpenApi, :call, [conn, open_api_opts])
+        apply(AshJsonApi.Controllers.OpenApi, :call, [conn, opts])
 
       conn.method == "GET" && Enum.any?(json_schema, &(&1 == conn.path_info)) ->
         AshJsonApi.Controllers.Schema.call(conn, opts)
@@ -87,12 +85,6 @@ defmodule AshJsonApi.Controllers.Router do
             )
         end
     end
-  end
-
-  defp open_api_opts(opts) do
-    opts
-    |> Keyword.put(:modify, Keyword.get(opts, :modify_open_api))
-    |> Keyword.delete(:modify_open_api)
   end
 
   defp open_api_request?(conn, open_api) do

--- a/lib/ash_json_api/router.ex
+++ b/lib/ash_json_api/router.ex
@@ -43,6 +43,12 @@ defmodule AshJsonApi.Router do
       end
 
       match(_, to: AshJsonApi.Controllers.Router, init_opts: Keyword.put(opts, :domains, domains))
+
+      if Code.ensure_loaded?(OpenApiSpex) do
+        def spec do
+          AshJsonApi.OpenApi.spec(unquote(opts))
+        end
+      end
     end
   end
 end

--- a/test/acceptance/open_api_test.exs
+++ b/test/acceptance/open_api_test.exs
@@ -239,7 +239,7 @@ defmodule Test.Acceptance.OpenApiTest do
     end
   end
 
-  def modify(spec, _conn, _opts) do
+  def modify_open_api(spec, _conn, _opts) do
     %{spec | info: %{spec.info | title: "foobar"}}
   end
 
@@ -247,7 +247,7 @@ defmodule Test.Acceptance.OpenApiTest do
     api_spec =
       AshJsonApi.Controllers.OpenApi.spec(%{private: %{}},
         domains: [Blogs],
-        modify: {__MODULE__, :modify, []}
+        modify_open_api: {__MODULE__, :modify_open_api, []}
       )
 
     %{open_api_spec: api_spec}


### PR DESCRIPTION
The PR adds support for generating OpenAPI spec files with Mix tasks, instead of just in response to HTTP requests to the OpenAPI route.

Some new options are introduced that helps customizing the resulting spec:
- The OpenAPI title is now configurable with the `:open_api_title` opt.
- The OpenAPI version is now configurable with the `:open_api_version` opt.
- The OpenAPI server list was previously populated by getting the endpoint from a live `conn`. Since we want to support spec generation from the CLI and without access to an active connection, a new option `:phoenix_endpoint` is supported to statically provide a reference to the endpoint. Another option `:open_api_servers` is added if the user instead wants to specify a custom list of URLs.

```elixir
defmodule MyAppWeb.AshJsonApi do
  use AshJsonApi.Router,
    domains: [...],
    open_api: "/open_api",
    open_api_title: "Title",
    open_api_version: "1.0.0",
    open_api_servers: ["http://domain.com/api/v1"],
    phoenix_endpoint: MyAppWeb.Endpoint
end
```

The OpenAPI spec can be written to file using the Mix tasks provided by [OpenApiSpex](https://github.com/open-api-spex/open_api_spex).

```sh
mix openapi.spec.json --spec MyAppWeb.AshJsonApi
mix openapi.spec.yaml --spec MyAppWeb.AshJsonApi
```

A new section is added to the documentation to describe how to use the new options and how to generate the spec file via CLI.

Fixes #129

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
