### PR TITLE
fix: reject allow_nil_input fields in required_write_attributes

### DIFF
--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -927,7 +927,10 @@ defmodule AshJsonApi.JsonSchema do
         resource
         |> Ash.Resource.Info.attributes()
         |> Enum.filter(&(&1.name in action.accept && &1.writable?))
-        |> Enum.reject(&(&1.allow_nil? || not is_nil(&1.default) || &1.generated?))
+        |> Enum.reject(
+          &(&1.allow_nil? || not is_nil(&1.default) || &1.generated? ||
+              &1.name in action.allow_nil_input)
+        )
         |> Enum.map(&to_string(&1.name))
       end
 

--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -929,7 +929,7 @@ defmodule AshJsonApi.JsonSchema do
         |> Enum.filter(&(&1.name in action.accept && &1.writable?))
         |> Enum.reject(
           &(&1.allow_nil? || not is_nil(&1.default) || &1.generated? ||
-              &1.name in action.allow_nil_input)
+             &1.name in Map.get(action, :allow_nil_input, []))
         )
         |> Enum.map(&to_string(&1.name))
       end

--- a/test/acceptance/patch_test.exs
+++ b/test/acceptance/patch_test.exs
@@ -147,10 +147,10 @@ defmodule Test.Acceptance.PatchTest do
 
       update :update do
         primary? true
-        accept([:id, :email])
+        accept([:id, :email, :name])
         argument(:author, :map)
         require_atomic?(false)
-
+        allow_nil_input([:name])
         change(manage_relationship(:author, type: :append_and_remove))
       end
 
@@ -175,7 +175,7 @@ defmodule Test.Acceptance.PatchTest do
 
     attributes do
       uuid_primary_key(:id, writable?: true)
-      attribute(:name, :string, public?: true)
+      attribute(:name, :string, public?: true, allow_nil?: false)
 
       attribute(:email, :string,
         public?: true,


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

---

I think allow_nil_input should be used in json api schema, but it wasn't.
Without this fix, I cannot make `allow_nil?: false` attributes to be optionally acceptable paramter in api.