### PR TITLE
docs: Remove erroneous " in generic action docs

### DIFF
--- a/documentation/dsls/DSL-AshJsonApi.Domain.md
+++ b/documentation/dsls/DSL-AshJsonApi.Domain.md
@@ -660,7 +660,7 @@ A route for a generic action.
 
 ### Examples
 ```
-route :get, "say_hi/:name", :say_hello"
+route :get, "say_hi/:name", :say_hello
 ```
 
 
@@ -1171,7 +1171,7 @@ A route for a generic action.
 
 ### Examples
 ```
-route :get, "say_hi/:name", :say_hello"
+route :get, "say_hi/:name", :say_hello
 ```
 
 

--- a/documentation/dsls/DSL-AshJsonApi.Resource.md
+++ b/documentation/dsls/DSL-AshJsonApi.Resource.md
@@ -575,7 +575,7 @@ A route for a generic action.
 
 ### Examples
 ```
-route :get, "say_hi/:name", :say_hello"
+route :get, "say_hi/:name", :say_hello
 ```
 
 

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -336,7 +336,7 @@ defmodule AshJsonApi.Resource do
     args: [:method, :route, :action],
     describe: "A route for a generic action.",
     examples: [
-      ~S{route :get, "say_hi/:name", :say_hello"}
+      ~S{route :get, "say_hi/:name", :say_hello}
     ],
     schema:
       Keyword.put(@route_schema, :method,


### PR DESCRIPTION
From the docs that can be seen here https://hexdocs.pm/ash_json_api/dsl-ashjsonapi-resource.html#examples-12 