### PR TITLE
On igniter install modify project aliases with expanded routes task

### DIFF
--- a/lib/ash_json_api/igniter.ex
+++ b/lib/ash_json_api/igniter.ex
@@ -158,6 +158,11 @@ if Code.ensure_loaded?(Igniter) do
       end
     end
 
+    def setup_routes_alias(igniter) do
+      alias = ["phx.routes", "ash_json_api.routes"]
+      Igniter.Project.TaskAliases.add_alias(igniter, "phx.routes", alias)
+    end
+
     defp update_endpoints(igniter, router) do
       {igniter, endpoints_that_need_parser} =
         Igniter.Libs.Phoenix.endpoints_for_router(igniter, router)

--- a/lib/ash_json_api/igniter.ex
+++ b/lib/ash_json_api/igniter.ex
@@ -159,8 +159,12 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     def setup_routes_alias(igniter) do
-      alias = ["phx.routes", "ash_json_api.routes"]
-      Igniter.Project.TaskAliases.add_alias(igniter, "phx.routes", alias)
+      Igniter.Project.TaskAliases.add_alias(
+        igniter,
+        "phx.routes",
+        ["phx.routes", "ash_json_api.routes"],
+        if_exists: {:append, "ash_json_api.routes"}
+      )
     end
 
     defp update_endpoints(igniter, router) do

--- a/lib/mix/tasks/ash_json_api.install.ex
+++ b/lib/mix/tasks/ash_json_api.install.ex
@@ -7,7 +7,10 @@ if Code.ensure_loaded?(Igniter) do
 
     def info(_argv, _parent) do
       %Igniter.Mix.Task.Info{
-        adds_deps: [{:open_api_spex, "~> 3.0"}]
+        adds_deps: [{:open_api_spex, "~> 3.0"}],
+        aliases: [
+          "phx.routes": ["phx.routes", "ash_json_api.routes"]
+        ]
       }
     end
 
@@ -34,6 +37,7 @@ if Code.ensure_loaded?(Igniter) do
         )
         |> AshJsonApi.Igniter.setup_ash_json_api_router(ash_phoenix_router_name)
         |> AshJsonApi.Igniter.setup_phoenix(ash_phoenix_router_name)
+        |> AshJsonApi.Igniter.setup_routes_alias()
       else
         igniter
         |> Igniter.add_warning("AshJsonApi router already exists, skipping installation.")

--- a/test/mix/tasks/ash_json_api.install_test.exs
+++ b/test/mix/tasks/ash_json_api.install_test.exs
@@ -1,0 +1,17 @@
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+defmodule Mix.Tasks.AshJsonApi.InstallTest do
+  use ExUnit.Case
+
+  import Igniter.Test
+
+  test "installation modifies the mix.exs aliases with alias for getting all routes" do
+    test_project()
+    |> apply_igniter!()
+    |> Igniter.compose_task("ash_json_api.install")
+    |> assert_has_patch("mix.exs", """
+    30 + |  defp aliases() do
+    31 + |    ["phx.routes": ["phx.routes", "ash_json_api.routes"]]
+    32 + |  end
+    """)
+  end
+end


### PR DESCRIPTION
Follow up to [make a follow up to add to the alias for phx.routes](https://github.com/ash-project/ash_json_api/pull/281#issuecomment-2620493935)

`ash_authentication_phoenix` didn't have what I was looking for but found it in the end 👀 
nifty `Igniter.Project.TaskAliases.add_alias/4` 🙌 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
