### PR TITLE
Use debug log level for errors by default

### DIFF
--- a/lib/ash_json_api/error/error.ex
+++ b/lib/ash_json_api/error/error.ex
@@ -160,7 +160,14 @@ defmodule AshJsonApi.Error do
           "No description"
       end
 
-    [code, title, " | ", description]
+    source_pointer =
+      if is_bitstring(error.source_pointer) do
+        error.source_pointer
+      else
+        "|"
+      end
+
+    [code, title, " ", source_pointer, " ", description]
   end
 
   def with_source_pointer(%{source_pointer: source_pointer} = built_error, _, _, _)

--- a/lib/ash_json_api/error/error.ex
+++ b/lib/ash_json_api/error/error.ex
@@ -10,7 +10,7 @@ defmodule AshJsonApi.Error do
             meta: :undefined,
             status_code: :undefined,
             internal_description: nil,
-            log_level: :error
+            log_level: :debug
 
   @type t :: %__MODULE__{}
 


### PR DESCRIPTION
https://discord.com/channels/711271361523351632/1254774851428814930/1337754359957553152

It introduces two improvements. The first one is about not logging validation error (and similar issues) as errors (@zachdaniel this might be a breaking change for some people). The second one is including source pointer in the message. This way, you will see

> [debug] invalid_attribute: InvalidAttribute /data/attributes/phone_number must be a valid E164 formatted phone number

instead of

> [debug] invalid_attribute: InvalidAttribute | must be a valid E164 formatted phone number