### PR TITLE
fix(docs): "graphql" used instead of "json_api"

### DIFF
--- a/documentation/topics/authorize-with-json-api.md
+++ b/documentation/topics/authorize-with-json-api.md
@@ -1,6 +1,6 @@
 # Authorize with AshJsonApi
 
-By default, `authorize?` in the domain is set to true. To disable authorization entirely for a given domain in graphql, use:
+By default, `authorize?` in the domain is set to true. To disable authorization entirely for a given domain in json_api, use:
 
 ```elixir
 json_api do


### PR DESCRIPTION
This PR fixes a typo.

I also found another instance where "Graphql" is used instead of "json_api" here:
https://github.com/Undeadlol1/ash_json_api/blob/1a6446e681042483a0a0f540307a03b1b60524fe/documentation/topics/upgrade.md#errors:~:text=around%20Ash%20and-,AshGraphql,-.%20To%20implement%20custom

This is most likely a proper usage of the word and does not need to change. But I would like a confirmation please.