### PR TITLE
Fix crash with embedded resource arguments in OpenAPI

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -809,7 +809,11 @@ if Code.ensure_loaded?(OpenApiSpex) do
         | constraints: Ash.Type.NewType.constraints(resource, attribute.constraints)
       }
 
-      resource = Ash.Type.NewType.subtype_of(resource)
+      resource =
+        case attribute.constraints[:instance_of] do
+          nil -> Ash.Type.NewType.subtype_of(resource)
+          type -> type
+        end
 
       create_action =
         case attribute.constraints[:create_action] do

--- a/test/acceptance/open_api_test.exs
+++ b/test/acceptance/open_api_test.exs
@@ -78,6 +78,7 @@ defmodule Test.Acceptance.OpenApiTest do
 
       action :get_foo, :struct do
         constraints(instance_of: Foo)
+        argument(:bio, :struct, allow_nil?: false, constraints: [instance_of: Bio])
 
         run(fn input, _ ->
           {:ok, %Foo{foo: "bar"}}
@@ -383,7 +384,22 @@ defmodule Test.Acceptance.OpenApiTest do
 
     assert [] = generic_action_schema.parameters
 
-    refute generic_action_schema.requestBody
+    assert %OpenApiSpex.Schema{
+             type: :object,
+             required: [:bio],
+             properties: %{
+               bio: %OpenApiSpex.Schema{
+                 type: :object,
+                 properties: %{
+                   history: %{
+                     "anyOf" => [%OpenApiSpex.Schema{type: :string}, %{"type" => "null"}]
+                   }
+                 }
+               }
+             },
+             additionalProperties: false
+           } =
+             generic_action_schema.requestBody.content["application/vnd.api+json"].schema.properties.data
 
     assert %OpenApiSpex.Schema{
              type: :object,


### PR DESCRIPTION
Fixes an issue where passing `:struct, constraints: [instance_of: resource]` as an argument would cause an error due to how `Ash.Type.Struct` was being used.

```
** (ArgumentError) `Ash.Type.Struct` is not a Spark DSL module.

    (ash 3.5.0) Ash.Type.Struct.entities([:actions])
    (spark 2.2.48) lib/spark/dsl/extension.ex:202: Spark.Dsl.Extension.get_entities/2
    (ash 3.5.0) lib/ash/resource/info.ex:567: Ash.Resource.Info.primary_action/2
    (ash_json_api 1.4.23) lib/ash_json_api/json_schema/open_api.ex:818: AshJsonApi.OpenApi.embedded_type_input/3
    iex:8: (file)
```

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
