### PR TITLE
Refactor `filter_type/2` of `OpenAPI` with `raw_filter_type/2`

### DIFF
--- a/test/ash_json_api/json_schema/open_api_test.exs
+++ b/test/ash_json_api/json_schema/open_api_test.exs
@@ -90,6 +90,7 @@ defmodule AshJsonApi.OpenApiTest do
                {"post-filter-view_count",
                 %OpenApiSpex.Schema{
                   type: :object,
+                  description: "View count of the post",
                   properties: %{
                     in: %OpenApiSpex.Schema{
                       type: :array,
@@ -116,6 +117,7 @@ defmodule AshJsonApi.OpenApiTest do
                {"author-filter-posts_count",
                 %OpenApiSpex.Schema{
                   type: :object,
+                  description: "Count of posts",
                   properties: %{
                     in: %OpenApiSpex.Schema{
                       type: :array,
@@ -136,6 +138,7 @@ defmodule AshJsonApi.OpenApiTest do
                {"post-filter-calc",
                 %OpenApiSpex.Schema{
                   type: :object,
+                  description: "A calculation",
                   properties: %{
                     in: %OpenApiSpex.Schema{
                       type: :array,
@@ -150,6 +153,7 @@ defmodule AshJsonApi.OpenApiTest do
                     greater_than_or_equal: %OpenApiSpex.Schema{type: :string},
                     contains: %OpenApiSpex.Schema{type: :string}
                   },
+                  required: [],
                   additionalProperties: false
                 }}
              ]
@@ -208,7 +212,8 @@ defmodule AshJsonApi.OpenApiTest do
                  less_than: %OpenApiSpex.Schema{type: :string},
                  greater_than: %OpenApiSpex.Schema{type: :string},
                  less_than_or_equal: %OpenApiSpex.Schema{type: :string},
-                 greater_than_or_equal: %OpenApiSpex.Schema{type: :string}
+                 greater_than_or_equal: %OpenApiSpex.Schema{type: :string},
+                 contains: %OpenApiSpex.Schema{type: :string}
                },
                required: [],
                additionalProperties: false


### PR DESCRIPTION
This PR resolves #316.

- Making `filter_type/2` internally delegate to `raw_filter_type/2` to reduce duplication.
- Replacing the ambiguous term `attribute_or_aggregate` with a clearer term, `field`.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
