### PR TITLE
Support `UUIDv7`, `Time` type in `AshJsonApi.OpenApi`

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -737,7 +737,21 @@ if Code.ensure_loaded?(OpenApiSpex) do
       }
     end
 
+    defp resource_attribute_type(%{type: Ash.Type.Time}, _resource, _format) do
+      %Schema{
+        type: :string,
+        format: "time"
+      }
+    end
+
     defp resource_attribute_type(%{type: Ash.Type.UUID}, _resource, _format) do
+      %Schema{
+        type: :string,
+        format: "uuid"
+      }
+    end
+
+    defp resource_attribute_type(%{type: Ash.Type.UUIDv7}, _resource, _format) do
       %Schema{
         type: :string,
         format: "uuid"


### PR DESCRIPTION
Partially resolves #306.
Fixes missing JSON schema representation for these types in `ash_ai`

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
