### PR TITLE
fix: config swagger to use bearer auth

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -95,7 +95,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
         },
         security: [
           %{
-            # API Key security applies to all operations
+            # bearer auth security applies to all operations
             "bearerAuth" => []
           }
         ]

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -85,18 +85,18 @@ if Code.ensure_loaded?(OpenApiSpex) do
           responses: AshJsonApi.OpenApi.responses(),
           schemas: AshJsonApi.OpenApi.schemas(domains),
           securitySchemes: %{
-            "api_key" => %SecurityScheme{
-              type: "apiKey",
-              description: "API Key provided in the Authorization header",
-              name: "api_key",
-              in: "header"
+            "bearerAuth" => %SecurityScheme{
+              type: "http",
+              description: "JWT for bearer authentication",
+              scheme: "bearer",
+              bearerFormat: "JWT"
             }
           }
         },
         security: [
           %{
             # API Key security applies to all operations
-            "api_key" => []
+            "bearerAuth" => []
           }
         ]
       }


### PR DESCRIPTION
This sends an `Authorization: Bearer $jwt` header instead of `api_key: $api_key` header, to match how `ash_authentication` expects it to be sent by default.

Closes #321

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
