### PR TITLE
chore: cleanup patch test now that underlying ash issue resolved

### DIFF
--- a/test/acceptance/patch_test.exs
+++ b/test/acceptance/patch_test.exs
@@ -126,10 +126,8 @@ defmodule Test.Acceptance.PatchTest do
       end
 
       update :update_preferences do
+        require_atomic?(false)
         accept([:preferences])
-
-        # NOTE: Uncomment this line to make failing test pass
-        # change(before_action(fn changeset, _ctx -> changeset end))
       end
     end
 


### PR DESCRIPTION
A couple of tweaks following on from #336 

- Action was missing `require_atomic?(false)` 
- Test passes when running against ash main, so comment lines can be removed.