### PR TITLE
improvement: add always_include_linkage param to resources

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 spark_locals_without_parens = [
+  always_include_linkage: 1,
   authorize?: 1,
   base: 1,
   base_route: 1,

--- a/documentation/dsls/DSL-AshJsonApi.Resource.md
+++ b/documentation/dsls/DSL-AshJsonApi.Resource.md
@@ -62,6 +62,7 @@ end
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`type`](#json_api-type){: #json_api-type } | `String.t` |  | The resource identifier type of this resource in JSON:API |
+| [`always_include_linkage`](#json_api-always_include_linkage){: #json_api-always_include_linkage } | `list(atom)` | `[]` | A list of relationships that should always have their linkage included in the resource |
 | [`includes`](#json_api-includes){: #json_api-includes } | `any \| list(any)` | `[]` | A keyword list of all paths that are includable from this resource |
 | [`include_nil_values?`](#json_api-include_nil_values?){: #json_api-include_nil_values? } | `any` |  | Whether or not to include properties for values that are nil in the JSON output |
 | [`default_fields`](#json_api-default_fields){: #json_api-default_fields } | `list(atom)` |  | The fields to include in the object if the `fields` query parameter does not specify. Defaults to all public |

--- a/lib/ash_json_api/resource/info.ex
+++ b/lib/ash_json_api/resource/info.ex
@@ -15,6 +15,10 @@ defmodule AshJsonApi.Resource.Info do
     Extension.get_opt(resource, [:json_api], :derive_sort, true, false)
   end
 
+  def always_include_linkage(resource) do
+    Extension.get_opt(resource, [:json_api], :always_include_linkage, [], false)
+  end
+
   def includes(resource) do
     Extension.get_opt(resource, [:json_api], :includes, [], false)
   end

--- a/lib/ash_json_api/resource/resource.ex
+++ b/lib/ash_json_api/resource/resource.ex
@@ -494,6 +494,12 @@ defmodule AshJsonApi.Resource do
         type: :string,
         doc: "The resource identifier type of this resource in JSON:API"
       ],
+      always_include_linkage: [
+        type: {:list, :atom},
+        doc:
+          "A list of relationships that should always have their linkage included in the resource",
+        default: []
+      ],
       includes: [
         type: {:wrap_list, :any},
         default: [],

--- a/test/spec_compliance/fetching_data/inclusion_of_linkage_test.exs
+++ b/test/spec_compliance/fetching_data/inclusion_of_linkage_test.exs
@@ -1,0 +1,261 @@
+defmodule AshJsonApiTest.FetchingData.InclusionOfLinkage do
+  use ExUnit.Case
+  @moduletag :json_api_spec_1_0
+
+  defmodule Author do
+    use Ash.Resource,
+      domain: AshJsonApiTest.FetchingData.InclusionOfLinkage.Domain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshJsonApi.Resource]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("author")
+
+      routes do
+        base("/authors")
+        get(:read)
+        index(:read)
+      end
+
+      always_include_linkage([:posts])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, public?: true)
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    relationships do
+      has_many(:posts, AshJsonApiTest.FetchingData.InclusionOfLinkage.Post,
+        public?: true,
+        destination_attribute: :author_id
+      )
+    end
+  end
+
+  defmodule Post do
+    use Ash.Resource,
+      domain: AshJsonApiTest.FetchingData.InclusionOfLinkage.Domain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshJsonApi.Resource]
+
+    actions do
+      default_accept(:*)
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("post")
+
+      routes do
+        base("/posts")
+        get(:read)
+        index(:read)
+      end
+
+      always_include_linkage([:author, :comments])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, public?: true)
+    end
+
+    relationships do
+      belongs_to(:author, Author, public?: true)
+
+      has_many(:comments, AshJsonApiTest.FetchingData.InclusionOfLinkage.Comment, public?: true)
+    end
+  end
+
+  defmodule Comment do
+    use Ash.Resource,
+      domain: AshJsonApiTest.FetchingData.InclusionOfLinkage.Domain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshJsonApi.Resource]
+
+    actions do
+      default_accept(:*)
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("comment")
+      default_fields [:text, :calc]
+
+      always_include_linkage([:post])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:text, :string, public?: true)
+    end
+
+    calculations do
+      calculate(:calc, :string, expr("hello"))
+    end
+
+    relationships do
+      belongs_to(:post, Post, public?: true)
+    end
+  end
+
+  defmodule Domain do
+    use Ash.Domain,
+      otp_app: :ash_json_api,
+      extensions: [
+        AshJsonApi.Domain
+      ]
+
+    resources do
+      resource(Author)
+      resource(Post)
+      resource(Comment)
+    end
+  end
+
+  defmodule Router do
+    use AshJsonApi.Router, domain: Domain
+  end
+
+  import AshJsonApi.Test
+
+  setup do
+    Application.put_env(:ash_json_api, Domain, json_api: [test_router: Router])
+
+    :ok
+  end
+
+  # credo:disable-for-this-file Credo.Check.Readability.MaxLineLength
+
+  describe "always_include_linkage option" do
+    @describetag :spec_may
+    test "resource endpoint with always_include_linkage of empty to-one relationship" do
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.create!()
+
+      assert %{
+               resp_body: %{
+                 "data" => %{
+                   "relationships" => %{
+                     "author" => %{"data" => nil}
+                   }
+                 },
+                 "included" => included
+               }
+             } = get(Domain, "/posts/#{post.id}/", status: 200)
+
+      assert included == []
+    end
+
+    test "resource endpoint with always_include_linkage of to-one relationship" do
+      # GET /posts/1
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.create!()
+
+      author_id = author.id
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.Changeset.manage_relationship(:author, author, type: :append_and_remove)
+        |> Ash.create!()
+
+      assert %{
+               resp_body: %{
+                 "data" => %{
+                   "relationships" => %{
+                     "author" => %{"data" => %{"id" => ^author_id, "type" => "author"}}
+                   }
+                 },
+                 "included" => included
+               }
+             } = get(Domain, "/posts/#{post.id}/", status: 200)
+
+      assert included == []
+    end
+
+    test "resource endpoint with always_include_linkage of empty to-many relationship" do
+      # GET /posts/1
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.create!()
+
+      assert %{
+               resp_body: %{
+                 "data" => %{
+                   "relationships" => %{
+                     "comments" => %{"data" => []}
+                   }
+                 },
+                 "included" => included
+               }
+             } = get(Domain, "/posts/#{post.id}/", status: 200)
+
+      assert included == []
+    end
+
+    test "resource endpoint with always_include_linkage of to-many relationship" do
+      # GET /posts/1
+      author =
+        Author
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.Changeset.manage_relationship(:author, author, type: :append_and_remove)
+        |> Ash.create!()
+
+      %{id: comment1_id} =
+        Comment
+        |> Ash.Changeset.for_create(:create, %{post_id: post.id, text: "foo"})
+        |> Ash.create!()
+
+      %{id: comment2_id} =
+        Comment
+        |> Ash.Changeset.for_create(:create, %{post_id: post.id, text: "bar"})
+        |> Ash.create!()
+
+      assert %{
+               resp_body: %{
+                 "data" => %{
+                   "relationships" => %{
+                     "comments" => %{"data" => linkage}
+                   }
+                 },
+                 "included" => included
+               }
+             } = get(Domain, "/posts/#{post.id}/", status: 200)
+
+      assert Enum.member?(linkage, %{"id" => comment1_id, "type" => "comment"})
+      assert Enum.member?(linkage, %{"id" => comment2_id, "type" => "comment"})
+      assert Enum.count(linkage) == 2
+
+      assert included == []
+    end
+  end
+end


### PR DESCRIPTION
This PR implements an `always_include_linkage` option on resources, that takes a list of relations that should have their linkage data always included in the resource's payload.

I implemented this for compatibility with ember-data in an application where I'm replacing jsonapi_resources (rails) by ash_json_api.

I'm not sure this should be merged:

1) It adds (unnecessary?) complexity.
2) It automatically triggers extra preloads, lowering the includes query param explicitness.
3) It seems this behavior is jsonapi_resources specific, not implemented in other jsonapi libs.

It could also have advantages, because clearly in the app I'm working on, it considerably reduces the number of requests. But it could also be due to poor query management by the old version of ember-data used by said app, and I don't have enough hindsight to be sure.

Please feel free to close.



# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
