### PR TITLE
fix: include generic GET action arguments as query parameters in JSON schema

### DIFF
--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -675,7 +675,7 @@ defmodule AshJsonApi.JsonSchema do
       }
     }
 
-    if route.type in [:get, :related] do
+    if route.type in [:get, :related] or (route.type == :route and route.method == :get) do
       props
       |> add_route_properties(resource, properties)
       |> add_read_arguments(route, resource)

--- a/test/acceptance/generic_action_index_test.exs
+++ b/test/acceptance/generic_action_index_test.exs
@@ -141,4 +141,21 @@ defmodule Test.Acceptance.GenericActionIndexTest do
     assert String.contains?(source_pointer, "query"),
            "Expected source pointer '#{source_pointer}' to contain field name 'query'"
   end
+
+  test "generic GET actions include arguments as query parameters in JSON schema" do
+    schema = AshJsonApi.JsonSchema.generate([Domain])
+
+    assert %{
+             "method" => "GET",
+             "rel" => "route",
+             "hrefSchema" => %{
+               "properties" => properties,
+               "required" => required
+             }
+           } = Enum.find(schema["links"], &(&1["method"] == "GET" and &1["rel"] == "route"))
+
+    assert Map.has_key?(properties, "query")
+    assert Map.has_key?(properties, "category")
+    assert "query" in required
+  end
 end


### PR DESCRIPTION

This PR fixes the JSON schema generation for generic GET actions, ensuring that all action arguments (required and optional) are included as query parameters in the generated schema. Also adds a test to verify this behavior [#349](https://github.com/ash-project/ash_json_api/issues/349)
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] Bug fixes include regression tests
