### PR TITLE
fix: empty includes should not crash

### DIFF
--- a/lib/ash_json_api/includes/parser.ex
+++ b/lib/ash_json_api/includes/parser.ex
@@ -29,7 +29,7 @@ defmodule AshJsonApi.Includes.Parser do
     |> to_nested_map()
   end
 
-  defp to_nested_map([]), do: true
+  # defp to_nested_map([]), do: true
 
   defp to_nested_map(list) when is_list(list) do
     list

--- a/lib/ash_json_api/includes/parser.ex
+++ b/lib/ash_json_api/includes/parser.ex
@@ -29,8 +29,6 @@ defmodule AshJsonApi.Includes.Parser do
     |> to_nested_map()
   end
 
-  # defp to_nested_map([]), do: true
-
   defp to_nested_map(list) when is_list(list) do
     list
     |> Enum.map(fn


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I can't remember why I added this line. It makes Ash crash when `includes` is an empty list and the query still provides one. Removing it allows for a better error msg.