### PR TITLE
fix: remove unnecessary warning for recursive embedded types

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -948,13 +948,8 @@ if Code.ensure_loaded?(OpenApiSpex) do
               type_key = {instance_of, nil, constraints}
 
               if type_key in acc.seen_non_schema_types do
-                # We're in a recursive loop, return $ref and warn
+                # We're in a recursive loop, return $ref
                 # Recursive type detected, using $ref instead of inline definition
-
-                Logger.warning(
-                  "Detected recursive embedded type with JSON API type: #{inspect(instance_of)}"
-                )
-
                 schema = %{"$ref" => "#/components/schemas/#{json_api_type}-type"}
                 {schema, acc}
               else


### PR DESCRIPTION
## Summary

Removes the unnecessary warning that appears when processing recursive embedded resources in OpenAPI schema generation. The code already correctly handles recursion by using `$ref` references, so the warning is misleading and makes it seem like something is wrong when the behavior is actually expected and properly handled.

## Changes

- Removed `Logger.warning` call in `lib/ash_json_api/json_schema/open_api.ex` when detecting recursive embedded types
- Updated test in `test/acceptance/json_schema_test.exs` to remove log capture and warning assertion