### PR TITLE
docs: add modify-conn guide to generated documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -69,6 +69,7 @@ defmodule AshJsonApi.MixProject do
         "documentation/topics/authorize-with-json-api.md",
         "documentation/topics/authenticate-with-json-api.md",
         "documentation/topics/paginated-relationships.md",
+        "documentation/topics/modify-conn.md",
         {"documentation/dsls/DSL-AshJsonApi.Resource.md",
          search_data: Spark.Docs.search_data_for(AshJsonApi.Resource)},
         {"documentation/dsls/DSL-AshJsonApi.Domain.md",


### PR DESCRIPTION
Adds the existing modify-conn guide to the docs navigation.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
