### PR TITLE
Add with_all_related_resources to resource schemas

### DIFF
--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -168,6 +168,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
           {resource_schemas, acc} =
             domain
             |> resources()
+            |> with_all_related_resources()
             |> Enum.reduce({[], acc}, fn resource, {schemas, acc} ->
               {schema, acc} = resource_object_schema(resource, nil, acc)
               schema_entry = {AshJsonApi.Resource.Info.type(resource), schema}


### PR DESCRIPTION
This will make it possible to generate a valid schema containing related resources without adding the whole domain when generating specs
Currently swagger fails as the schema for related resources are not contained in the definition unless the whole domain for the related resources are added to `AshJsonApi.Router -> domains`

No tests broke and in my own setup it only added the schemas I was missing.
Cannot currently see any unwanted side-effect.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
