### PR TITLE
Fix BadMapError when page param is not using bracket notation

### DIFF
--- a/lib/ash_json_api/controllers/helpers.ex
+++ b/lib/ash_json_api/controllers/helpers.ex
@@ -933,6 +933,17 @@ defmodule AshJsonApi.Controllers.Helpers do
 
   # This doesn't need to use chain, because its stateless and safe to
   # do anytime. Returning multiple errors is a nice feature of JSON API
+  def fetch_pagination_parameters(%{query_params: %{"page" => page}} = request)
+      when is_binary(page) do
+    Request.add_error(
+      request,
+      Error.InvalidPagination.exception(
+        detail: "page parameter must use bracket notation (e.g., page[limit]=10&page[offset]=0)"
+      ),
+      :read
+    )
+  end
+
   def fetch_pagination_parameters(request) do
     if request.action.type == :read do
       request

--- a/test/acceptance/index_pagination_test.exs
+++ b/test/acceptance/index_pagination_test.exs
@@ -116,5 +116,20 @@ defmodule Test.Acceptance.IndexPaginationTest do
       data = response.resp_body["data"]
       assert length(data) == 5
     end
+
+    @tag capture_log: true
+    test "returns 400 when page parameter is not using bracket notation" do
+      # Clients must use page[limit]=10 format, not page={"limit":10} or similar
+      # URL-encoded: %7B%22limit%22%3A1%7D = {"limit":1}
+      response =
+        Domain
+        |> get("/posts?page=%7B%22limit%22%3A1%7D", status: 400)
+
+      errors = response.resp_body["errors"]
+
+      assert Enum.any?(errors, fn error ->
+               error["code"] == "invalid_pagination" and error["detail"] =~ "bracket notation"
+             end)
+    end
   end
 end


### PR DESCRIPTION
A client complained of 500 errors when they were sending query params as json in the query param by accident. It should return a structured error instead of 500'ing.

Issue and fix:
When clients send page parameter as a string (e.g., page={"limit":1})
instead of bracket notation (page[limit]=1), the pagination code would
crash with a BadMapError when calling Map.fetch on the string.

This adds a guard clause to fetch_pagination_parameters that detects
when page is a binary string and returns a structured 400 error
explaining the correct format, instead of crashing with a 500.

JSON:API spec requires bracket notation for nested query parameters.

