### PR TITLE
fix: Fix schema generation for calculcations marked with `allow_nil?: false`

### DIFF
--- a/lib/ash_json_api/json_schema/json_schema.ex
+++ b/lib/ash_json_api/json_schema/json_schema.ex
@@ -279,6 +279,7 @@ defmodule AshJsonApi.JsonSchema do
   defp required_attributes(resource) do
     resource
     |> Ash.Resource.Info.public_attributes()
+    |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
     |> filter_shown_fields(resource)
     |> Enum.reject(&(&1.allow_nil? || AshJsonApi.Resource.only_primary_key?(resource, &1.name)))
     |> Enum.map(&AshJsonApi.Resource.Info.field_to_json_key(resource, &1.name))

--- a/lib/ash_json_api/json_schema/open_api.ex
+++ b/lib/ash_json_api/json_schema/open_api.ex
@@ -429,6 +429,7 @@ if Code.ensure_loaded?(OpenApiSpex) do
     defp required_attributes(resource) do
       resource
       |> Ash.Resource.Info.public_attributes()
+      |> Enum.concat(Ash.Resource.Info.public_calculations(resource))
       |> filter_shown_fields(resource)
       |> Enum.reject(&(&1.allow_nil? || AshJsonApi.Resource.only_primary_key?(resource, &1.name)))
       |> Enum.map(fn attr ->

--- a/test/acceptance/json_schema_test.exs
+++ b/test/acceptance/json_schema_test.exs
@@ -113,6 +113,10 @@ defmodule Test.Acceptance.JsonSchemaTest do
       )
     end
 
+    calculations do
+      calculate(:always_flag, :boolean, expr(true), public?: true, allow_nil?: false)
+    end
+
     relationships do
       belongs_to(:author, Test.Acceptance.JsonSchemaTest.Author, allow_nil?: false, public?: true)
     end
@@ -348,6 +352,14 @@ defmodule Test.Acceptance.JsonSchemaTest do
       refute Map.has_key?(create_relationships["properties"], "hidden_author")
       assert "visible_author" in create_relationships["required"]
       refute "hidden_author" in create_relationships["required"]
+    end
+
+    test "does not make non-nilable calculations nullable", %{json_api: json_api} do
+      post_schema = json_api["definitions"]["post"]
+      attributes = post_schema["properties"]["attributes"]["properties"]
+
+      assert Map.has_key?(attributes, "always_flag")
+      refute Map.has_key?(attributes["always_flag"], "anyOf")
     end
 
     test "handles self-referential embedded resources without infinite loop" do

--- a/test/ash_json_api/json_schema/open_api_test.exs
+++ b/test/ash_json_api/json_schema/open_api_test.exs
@@ -73,6 +73,7 @@ defmodule AshJsonApi.OpenApiTest do
 
     calculations do
       calculate(:calc, :string, expr("calc"), description: "A calculation")
+      calculate(:always_flag, :boolean, expr(true), public?: true, allow_nil?: false)
     end
   end
 
@@ -82,6 +83,17 @@ defmodule AshJsonApi.OpenApiTest do
     resources do
       resource Author
       resource Post
+    end
+  end
+
+  describe "resource schemas" do
+    test "non-nilable calculations are not nullable" do
+      spec = AshJsonApi.OpenApi.spec(domain: [Blogs])
+      post = spec.components.schemas["post"]
+      flag = post.properties.attributes.properties["always_flag"]
+
+      refute Map.has_key?(flag, "anyOf")
+      refute Map.has_key?(flag, "nullable")
     end
   end
 


### PR DESCRIPTION
This PR fixes an issue where the schema that was generated for a calculcation with `allow_nil?: false` had a wrong type:
Before:
<img width="545" height="97" alt="image" src="https://github.com/user-attachments/assets/3891f979-d699-42d2-b1cc-f8b7b03cf66b" />
After:
<img width="357" height="36" alt="image" src="https://github.com/user-attachments/assets/614939a1-513e-4c9f-abdf-147a4236b28d" />


Fixed it by adding the 
`Ash.Resource.Info.public_calculations(resource)` to the `required_attributes` functions. 


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
