### PR TITLE
fix: resolve sparse fieldset types through include paths and router domains

### DIFF
--- a/lib/ash_json_api/request.ex
+++ b/lib/ash_json_api/request.ex
@@ -639,36 +639,9 @@ defmodule AshJsonApi.Request do
 
   defp parse_fields(%{query_params: %{"fields" => fields}} = request) when is_map(fields) do
     Enum.reduce(fields, request, fn {type, fields}, request ->
-      # Get all relevant resources better here, i.e using the includes keyword
-      # this could miss relationships to things in other apis
-      request.domain
-      |> Ash.Domain.Info.resources()
-      |> Enum.find(&(AshJsonApi.Resource.Info.type(&1) == type))
-      |> case do
+      case resource_for_type(request, type) do
         nil ->
-          request.domain
-          |> Spark.otp_app()
-          |> case do
-            nil ->
-              add_error(request, InvalidType.exception(type: type), request.route.type)
-
-            otp_app ->
-              otp_app
-              |> Application.get_env(:ash_domains, [])
-              |> Enum.find_value(fn domain ->
-                domain != request.domain &&
-                  domain
-                  |> Ash.Domain.Info.resources()
-                  |> Enum.find(&(AshJsonApi.Resource.Info.type(&1) == type))
-              end)
-              |> then(fn
-                nil ->
-                  add_error(request, InvalidType.exception(type: type), request.route.type)
-
-                resource ->
-                  add_fields(request, resource, fields, true)
-              end)
-          end
+          add_error(request, InvalidType.exception(type: type), request.route.type)
 
         resource ->
           add_fields(request, resource, fields, true)
@@ -686,6 +659,59 @@ defmodule AshJsonApi.Request do
   end
 
   defp parse_field_inputs(request), do: request
+
+  # Resolves a JSON:API type name to a resource, in order of specificity:
+  # the route's domain, destinations reachable through the request's validated
+  # include paths, the router's other domains, and finally any domain
+  # configured under the route domain's otp_app.
+  defp resource_for_type(request, type) do
+    find_resource_with_type(Ash.Domain.Info.resources(request.domain), type) ||
+      find_resource_with_type(included_resources(request), type) ||
+      find_resource_with_type(all_domain_resources(request), type) ||
+      otp_app_resource_with_type(request, type)
+  end
+
+  defp find_resource_with_type(resources, type) do
+    Enum.find(resources, &(AshJsonApi.Resource.Info.type(&1) == type))
+  end
+
+  # All intermediate and final destinations along the validated include paths:
+  # ["comments", "author"] contributes both destinations.
+  defp included_resources(request) do
+    request.includes
+    |> Enum.flat_map(&resources_on_path(request.resource, &1))
+    |> Enum.uniq()
+  end
+
+  defp resources_on_path(_resource, []), do: []
+
+  defp resources_on_path(resource, [segment | rest]) do
+    case public_related(resource, [segment]) do
+      nil -> []
+      destination -> [destination | resources_on_path(destination, rest)]
+    end
+  end
+
+  defp all_domain_resources(request) do
+    request.all_domains
+    |> Enum.reject(&(&1 == request.domain))
+    |> Enum.flat_map(&Ash.Domain.Info.resources/1)
+  end
+
+  defp otp_app_resource_with_type(request, type) do
+    case Spark.otp_app(request.domain) do
+      nil ->
+        nil
+
+      otp_app ->
+        otp_app
+        |> Application.get_env(:ash_domains, [])
+        |> Enum.find_value(fn domain ->
+          domain != request.domain &&
+            find_resource_with_type(Ash.Domain.Info.resources(domain), type)
+        end)
+    end
+  end
 
   defp public_related(resource, relationship) when not is_list(relationship) do
     public_related(resource, [relationship])
@@ -713,19 +739,20 @@ defmodule AshJsonApi.Request do
   end
 
   defp add_field_inputs(request, type, field_inputs) do
-    resource =
-      request.domain
-      |> Ash.Domain.Info.resources()
-      |> Enum.find(&(AshJsonApi.Resource.Info.type(&1) == type))
+    case resource_for_type(request, type) do
+      nil ->
+        add_error(request, InvalidType.exception(type: type), request.route.type)
 
+      resource ->
+        add_field_inputs_for_resource(request, resource, type, field_inputs)
+    end
+  end
+
+  defp add_field_inputs_for_resource(request, resource, type, field_inputs) do
     Enum.reduce(field_inputs, request, fn {calculation_name, arguments}, request ->
       resolved_name =
-        if resource do
-          AshJsonApi.Resource.Info.json_key_to_field(resource, calculation_name) ||
-            calculation_name
-        else
+        AshJsonApi.Resource.Info.json_key_to_field(resource, calculation_name) ||
           calculation_name
-        end
 
       case Ash.Resource.Info.public_calculation(resource, resolved_name) do
         nil ->

--- a/test/acceptance/cross_domain_fields_test.exs
+++ b/test/acceptance/cross_domain_fields_test.exs
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: 2019 ash_json_api contributors <https://github.com/ash-project/ash_json_api/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Test.Acceptance.CrossDomainFieldsTest do
+  use ExUnit.Case, async: true
+
+  defmodule Contact do
+    use Ash.Resource,
+      domain: Test.Acceptance.CrossDomainFieldsTest.ContactsDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshJsonApi.Resource]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("contact")
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:first_name, :string, public?: true)
+      attribute(:last_name, :string, public?: true)
+      attribute(:phone, :string, public?: true)
+    end
+
+    calculations do
+      calculate :full_name, :string, concat([:first_name, :last_name], arg(:separator)) do
+        argument(:separator, :string, default: " ")
+        public?(true)
+      end
+    end
+  end
+
+  defmodule User do
+    use Ash.Resource,
+      domain: Test.Acceptance.CrossDomainFieldsTest.UsersDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshJsonApi.Resource]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("user")
+      includes([:contact])
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, public?: true)
+    end
+
+    relationships do
+      belongs_to :contact, Contact do
+        public?(true)
+      end
+    end
+  end
+
+  # Holds Contact only; never routed to. Deliberately no otp_app.
+  defmodule ContactsDomain do
+    use Ash.Domain, extensions: [AshJsonApi.Domain]
+
+    resources do
+      resource(Contact)
+    end
+  end
+
+  # A decoy resource sharing the "contact" JSON:API type but without the
+  # Contact fields, to prove the include graph wins over a flat domain scan.
+  defmodule Decoy do
+    use Ash.Resource,
+      domain: Test.Acceptance.CrossDomainFieldsTest.DecoyDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshJsonApi.Resource]
+
+    ets do
+      private?(true)
+    end
+
+    json_api do
+      type("contact")
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:other_field, :string, public?: true)
+    end
+  end
+
+  defmodule DecoyDomain do
+    use Ash.Domain, extensions: [AshJsonApi.Domain]
+
+    resources do
+      resource(Decoy)
+    end
+  end
+
+  # Route domain: deliberately NO otp_app, so the legacy
+  # Spark.otp_app/:ash_domains fallback cannot resolve foreign types.
+  defmodule UsersDomain do
+    use Ash.Domain, extensions: [AshJsonApi.Domain]
+
+    json_api do
+      log_errors?(false)
+
+      routes do
+        base_route "/users", User do
+          index(:read)
+          get(:read)
+        end
+      end
+    end
+
+    resources do
+      resource(User)
+    end
+  end
+
+  defmodule Router do
+    # Only the route domain: cross-domain types must resolve via the
+    # request's include graph, not a scan of the router's domains.
+    use AshJsonApi.Router, domain: UsersDomain
+  end
+
+  defmodule MultiDomainRouter do
+    use AshJsonApi.Router, domains: [UsersDomain, ContactsDomain]
+  end
+
+  defmodule DecoyFirstRouter do
+    # DecoyDomain precedes ContactsDomain, so a flat all_domains scan would
+    # find Decoy first for the "contact" type.
+    use AshJsonApi.Router, domains: [UsersDomain, DecoyDomain, ContactsDomain]
+  end
+
+  import AshJsonApi.Test
+
+  setup do
+    contact =
+      Contact
+      |> Ash.Changeset.for_create(:create, %{
+        first_name: "Ada",
+        last_name: "Lovelace",
+        phone: "555-1234"
+      })
+      |> Ash.create!()
+
+    user =
+      User
+      |> Ash.Changeset.for_create(:create, %{name: "user1", contact_id: contact.id})
+      |> Ash.create!()
+
+    %{user: user, contact: contact}
+  end
+
+  test "include across domains works without sparse fieldsets", %{user: user} do
+    response = get(UsersDomain, "/users/#{user.id}?include=contact", router: Router, status: 200)
+
+    assert [%{"type" => "contact", "attributes" => attributes}] =
+             response.resp_body["included"]
+
+    assert Map.has_key?(attributes, "phone")
+  end
+
+  test "fields[contact] resolves the cross-domain included type and limits attributes",
+       %{user: user} do
+    response =
+      get(
+        UsersDomain,
+        "/users/#{user.id}?include=contact&fields[contact]=first_name,last_name",
+        router: Router,
+        status: 200
+      )
+
+    assert [%{"type" => "contact", "attributes" => attributes}] =
+             response.resp_body["included"]
+
+    assert attributes == %{"first_name" => "Ada", "last_name" => "Lovelace"}
+  end
+
+  test "fields[contact] works on the index route too" do
+    response =
+      get(
+        UsersDomain,
+        "/users?include=contact&fields[contact]=first_name",
+        router: Router,
+        status: 200
+      )
+
+    assert [%{"type" => "contact", "attributes" => %{"first_name" => "Ada"} = attributes}] =
+             response.resp_body["included"]
+
+    refute Map.has_key?(attributes, "phone")
+  end
+
+  test "unknown type in fields still returns 400 invalid_type", %{user: user} do
+    response =
+      get(
+        UsersDomain,
+        "/users/#{user.id}?include=contact&fields[nonexistent]=foo",
+        router: Router,
+        status: 400
+      )
+
+    assert [error | _] = response.resp_body["errors"]
+    assert error["code"] == "invalid_type"
+  end
+
+  test "field_inputs for a cross-domain included type are applied", %{user: user} do
+    response =
+      get(
+        UsersDomain,
+        "/users/#{user.id}?include=contact&fields[contact]=full_name&field_inputs[contact][full_name][separator]=%2C",
+        router: Router,
+        status: 200
+      )
+
+    assert [%{"type" => "contact", "attributes" => attributes}] =
+             response.resp_body["included"]
+
+    assert attributes == %{"full_name" => "Ada,Lovelace"}
+  end
+
+  test "fields[contact] resolves through the router's domains without an include",
+       %{user: user} do
+    response =
+      get(
+        UsersDomain,
+        "/users/#{user.id}?fields[contact]=first_name",
+        router: MultiDomainRouter,
+        status: 200
+      )
+
+    assert response.resp_body["data"]["type"] == "user"
+  end
+
+  test "the include-graph destination wins over same-typed resources in other router domains",
+       %{user: user} do
+    # first_name exists on Contact but not on Decoy; resolving via the flat
+    # domain scan would 400 with an invalid field error.
+    response =
+      get(
+        UsersDomain,
+        "/users/#{user.id}?include=contact&fields[contact]=first_name",
+        router: DecoyFirstRouter,
+        status: 200
+      )
+
+    assert [%{"type" => "contact", "attributes" => %{"first_name" => "Ada"}}] =
+             response.resp_body["included"]
+  end
+end


### PR DESCRIPTION
## Problem

A cross-domain included resource serializes fine, but adding a sparse fieldset for it fails when the route's domain has no `otp_app`:

```http
GET /api/users?include=contact                                      # 200, includes "type": "contact"
GET /api/users?include=contact&fields[contact]=first_name,last_name # 400 invalid_type "No such type contact"
```

`parse_fields/1` resolved `fields[type]` by scanning only the route domain's resources, then falling back to `Spark.otp_app(domain)` + `Application.get_env(otp_app, :ash_domains)`. With no `otp_app` (the shape shown in the getting-started docs), any type living in another domain immediately produced `invalid_type` — even though the relationship destination already identifies the resource unambiguously, and the serializer has no trouble with it (it reads the type off the record's struct module). A stale TODO comment in the code flagged exactly this gap.

## Fix

Type resolution now goes through a shared `resource_for_type/2` helper, in order of specificity:

1. **The route's domain** — unchanged behavior.
2. **Destination resources reachable through the request's validated include paths** — walked via the existing `public_related/2` relationship traversal, collecting intermediate and final destinations. The include graph names the exact resource that appears in `included`, so it takes precedence over unrelated resources that happen to share a JSON:API type name in another domain.
3. **The router's other domains** (`request.all_domains`).
4. **The legacy `otp_app`/`:ash_domains` fallback** — kept for backwards compatibility.

`add_field_inputs/3` had the same single-domain scan in a worse form: a cross-domain type yielded `resource = nil`, which was passed to `Ash.Resource.Info.public_calculation/2` and crashed. It now uses the shared lookup, so cross-domain `field_inputs` work and an unknown type returns a proper 400 `invalid_type` instead of a 500.

Minor behavior note: `fields[X]` for a type that exists in another router domain but isn't included in the response now resolves instead of 400ing. That's spec-compliant — JSON:API sparse fieldsets may name types that don't appear in the response document.

## Tests

New `test/acceptance/cross_domain_fields_test.exs`: two domains, route domain deliberately without `otp_app`, plus a decoy resource sharing the `"contact"` type in a third domain. Covers: plain cross-domain include (baseline), `fields[contact]` on get and index routes, cross-domain `field_inputs` on a calculation, resolution via the router's `domains:` list without an include, include-graph precedence over the decoy, and unknown types still returning 400 `invalid_type`.

Five of the seven tests fail without the lib change (verified by stashing it); the other two pin the invariants the fix must preserve. Full suite green (395 tests, 0 failures), `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)