### PR TITLE
feat: Implement `AshJsonApi.ToJsonApiError` for `Ash.Error.Query.NoSuchField`

### DIFF
--- a/lib/ash_json_api/error/error.ex
+++ b/lib/ash_json_api/error/error.ex
@@ -181,6 +181,14 @@ defmodule AshJsonApi.Error do
     [built_error]
   end
 
+  # Errors raised while applying query parameters to a read (e.g. `filter` or
+  # `sort`) carry the parameter name as the head of their path, so we surface
+  # that as `source.parameter` rather than a body pointer.
+  def with_source_pointer(built_error, %{path: [param | _]}, _resource, :read)
+      when param in [:filter, :sort] do
+    [%{built_error | source_parameter: to_string(param)}]
+  end
+
   def with_source_pointer(built_error, %{fields: fields, path: path}, resource, type)
       when is_list(fields) and fields != [] do
     Enum.map(fields, fn field ->
@@ -341,9 +349,35 @@ defimpl AshJsonApi.ToJsonApiError, for: Ash.Error.Query.NoSuchField do
     %AshJsonApi.Error{
       id: Ash.UUID.generate(),
       status_code: 400,
-      code: "invalid_query",
-      title: "InvalidQuery",
-      detail: "no such query parameter #{error.field}",
+      code: "no_such_field",
+      title: "NoSuchField",
+      detail: "no such field #{error.field}",
+      meta: error.vars |> Map.new() |> Map.put(:field, error.field)
+    }
+  end
+end
+
+defimpl AshJsonApi.ToJsonApiError, for: Ash.Error.Query.NoSuchFilterPredicate do
+  def to_json_api_error(error) do
+    %AshJsonApi.Error{
+      id: Ash.UUID.generate(),
+      status_code: 400,
+      code: "no_such_filter_predicate",
+      title: "NoSuchFilterPredicate",
+      detail: "no such filter predicate #{error.key}",
+      meta: error.vars |> Map.new() |> Map.put(:key, error.key)
+    }
+  end
+end
+
+defimpl AshJsonApi.ToJsonApiError, for: Ash.Error.Query.InvalidFilterValue do
+  def to_json_api_error(error) do
+    %AshJsonApi.Error{
+      id: Ash.UUID.generate(),
+      status_code: 400,
+      code: "invalid_filter_value",
+      title: "InvalidFilterValue",
+      detail: Ash.Error.Query.InvalidFilterValue.message(error),
       meta: Map.new(error.vars)
     }
   end

--- a/lib/ash_json_api/error/error.ex
+++ b/lib/ash_json_api/error/error.ex
@@ -336,6 +336,19 @@ defimpl AshJsonApi.ToJsonApiError, for: Ash.Error.Query.NotFound do
   end
 end
 
+defimpl AshJsonApi.ToJsonApiError, for: Ash.Error.Query.NoSuchField do
+  def to_json_api_error(error) do
+    %AshJsonApi.Error{
+      id: Ash.UUID.generate(),
+      status_code: 400,
+      code: "invalid_query",
+      title: "InvalidQuery",
+      detail: "no such query parameter #{error.field}",
+      meta: Map.new(error.vars)
+    }
+  end
+end
+
 defimpl AshJsonApi.ToJsonApiError, for: Ash.Error.Query.Required do
   def to_json_api_error(error) do
     %AshJsonApi.Error{

--- a/test/acceptance/error_validation_test.exs
+++ b/test/acceptance/error_validation_test.exs
@@ -98,6 +98,49 @@ defmodule Test.Acceptance.ErrorValidationTest do
     end
   end
 
+  describe "filter errors raised while reading" do
+    test "unknown filter field returns no_such_field with source parameter" do
+      response =
+        Domain
+        |> get("/posts/with_filter_sort?filter[foo]=value", status: 400)
+
+      assert [error] = response.resp_body["errors"]
+      assert error["code"] == "no_such_field"
+      assert error["title"] == "NoSuchField"
+      assert error["detail"] == "no such field foo"
+      assert error["meta"] == %{"field" => "foo"}
+      assert error["source"] == %{"parameter" => "filter"}
+      assert error["status"] == "400"
+    end
+
+    test "unknown filter predicate returns no_such_filter_predicate with source parameter" do
+      response =
+        Domain
+        |> get("/posts/with_filter_sort?filter[title][foo]=value", status: 400)
+
+      assert [error] = response.resp_body["errors"]
+      assert error["code"] == "no_such_filter_predicate"
+      assert error["title"] == "NoSuchFilterPredicate"
+      assert error["detail"] == "no such filter predicate foo"
+      assert error["meta"] == %{"key" => "foo"}
+      assert error["source"] == %{"parameter" => "filter"}
+      assert error["status"] == "400"
+    end
+
+    test "invalid filter value returns invalid_filter_value with source parameter" do
+      response =
+        Domain
+        |> get("/posts/with_filter_sort?filter[title][in]=x", status: 400)
+
+      assert [error] = response.resp_body["errors"]
+      assert error["code"] == "invalid_filter_value"
+      assert error["title"] == "InvalidFilterValue"
+      assert String.starts_with?(error["detail"], "Invalid filter value")
+      assert error["source"] == %{"parameter" => "filter"}
+      assert error["status"] == "400"
+    end
+  end
+
   describe "InvalidSort errors" do
     test "returns proper error when sort is invalid type on derive_sort?: true route" do
       # This triggers the error: derive_sort?: true but sort is array (not string)


### PR DESCRIPTION
This PR implements the `AshJsonApi.ToJsonApiError` protocol for the `Ash.Error.Query.NoSuchField` exception.

Right now, when a request with an invalid filter parameter (e.g. `GET /some/path?filter[foo]=value`) is made, it results in a generic error response:

```json
{
  "errors": [
    {
      "code": "something_went_wrong",
      "id": "7bacccd8-315d-4a1f-ae54-c873e3991c29",
      "status": "400",
      "title": "SomethingWentWrong",
      "detail": "Something went wrong. Error id: 7bacccd8-315d-4a1f-ae54-c873e3991c29"
    }
  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```

This is not particularly helpful, especially given that it was the client's fault. With the new implementation, you'll instead get something like this:

```json
{
  "errors": [
    {
      "code": "invalid_query",
      "id": "7bacccd8-315d-4a1f-ae54-c873e3991c29",
      "status": "400",
      "title": "InvalidQuery",
      "detail": "no such query parameter foo"
    }
  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```

This is _better_. It's still not ideal, as it doesn't point at the `filter` parameter, so if there's multiple `foo`s in there, it's ambiguous. I'm not sure how you'd deduce the fact that it was a `filter` parameter specifically from just the `NoSuchField` exception. If there's a way to do that, the error message could be even more helpful.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I didn't find any tests for the other implementations of that protocol. If I should add one, please let me know how/where and I will add one.